### PR TITLE
break config.json and data_config.json into separate  files

### DIFF
--- a/public/data_config.json
+++ b/public/data_config.json
@@ -1,0 +1,97 @@
+{
+  "dimensions": [
+    {
+      "name": "all",
+      "label": "Anywhere",
+      "value": "all"
+    },
+    {
+      "name": "sections",
+      "label": "In a section",
+      "value": "sections",
+
+      "querySet": "dimension_section_list",
+      "labelField": "description",
+      "valueField": "description"
+    }
+  ],
+  "filters": [
+    {
+      "name": "Comments",
+      "category": "Activity",
+      "field": "count",
+      "template": "statistics.comments.<%= dimension %>.all.count",
+      "description": "total comments",
+      "min": 0,
+      "max": 500,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    },
+    {
+      "name": "Replied",
+      "category": "Activity",
+      "field": "replied_count",
+      "template": "statistics.comments.<%= dimension %>.all.replied_count",
+      "description": "replies they have written to others",
+      "min": 0,
+      "max": 500,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    },
+    {
+      "name": "Replies",
+      "category": "Response",
+      "field": "reply_count",
+      "template": "statistics.comments.<%= dimension %>.all.reply_count",
+      "description": "times other have replied to them",
+      "min": 0,
+      "max": 500,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    },
+    {
+      "name": "Replies per Comment",
+      "category": "Response",
+      "field": "replied_ratio",
+      "template": "statistics.comments.<%= dimension %>.all.replied_ratio",
+      "description": "Percent of comments that are replies",
+      "min": 0,
+      "max": 1,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    },
+    {
+      "name": "Replied per Comment",
+      "category": "Response",
+      "field": "reply_ratio",
+      "template": "statistics.comments.<%= dimension %>.all.reply_ratio",
+      "description": "Replies from others per comment",
+      "min": 0,
+      "max": 50,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    },
+    {
+      "name": "Average Wordcount",
+      "category": "Content",
+      "field": "word_count_average",
+      "template": "statistics.comments.<%= dimension %>.all.word_count_average",
+      "description": "Average words per post",
+      "min": 0,
+      "max": 1000,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    },
+    {
+      "name": "Percent SystemFlagged",
+      "category": "Moderation",
+      "field": "SystemFlagged",
+      "template": "statistics.comments.<%= dimension %>.ratios.SystemFlagged",
+      "description": "Percent of comments SystemFlagged",
+      "min": 0,
+      "max": 1,
+      "collection": "user_statistics",
+      "type": "numberRange"
+    }
+  ]
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 export const CONFIG_LOADED = 'CONFIG_LOADED';
+export const DATA_CONFIG_LOADED = 'DATA_CONFIG_LOADED';
 
 export const PIPELINE_SELECTED = 'PIPELINE_SELECTED';
 export const PIPELINE_REQUEST = 'PIPELINE_REQUEST'; // request data for a single pipeline

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -22,7 +22,7 @@ let initialState = {
 const filters = (state = initialState, action) => {
   switch (action.type) {
 
-  case types.CONFIG_LOADED:
+  case types.DATA_CONFIG_LOADED:
     const filters = action.config.filters.reduce((accum, filter) => {
       accum[filter.field] = filter;
       accum[filter.field].userMin = filter.min;


### PR DESCRIPTION
## What?

we need to break functionality of the app into a separate config file than the environment stuff. This PR does just that, adding a `data_config.json` file to be tracked in VC.

https://github.com/coralproject/cay/issues/98

The only line I was concerned about was [this line](https://github.com/coralproject/cay/compare/config-breakup?expand=1#diff-1fdf421c05c1140f6d71444ea2b27638R109). I'm not sure what's going to happen in production (when `redbox-react` will not be enabled) 