### PR TITLE
Github Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce behavior

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## What does this PR do?
+
+## How do I test this PR?
+
+- click a button
+- view the cat
+- see the cat meow
+
+@coralproject/frontend


### PR DESCRIPTION
## What does this PR do?

Github templates are a great way to keep us honest with issues and PRs in our quest to have good public documentation. https://github.com/blog/2111-issue-and-pull-request-templates. I added some markdown files to `/.github/` in the project.

## How do I test this PR?

- open a new PR
- you should be able to see the text field pre-filled?
- I don't know if we can actually test this until it's merged to `master`

@coralproject/frontend
