### PR TITLE
Replace window.xeniaHost and window.pillarHost calls with

### DIFF
--- a/src/comments/CommentsActions.js
+++ b/src/comments/CommentsActions.js
@@ -31,8 +31,8 @@ export const receiveCommentsFailure = (err) => {
 /* xenia_package */
 export const fetchCommentsByUser = (user_id) => {
 
-  const url = `${window.xeniaHost}/1.0/exec/comments_by_user?user_id=${user_id}`;
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const url = `${getState().app.xeniaHost}/1.0/exec/comments_by_user?user_id=${user_id}`;
 
     dispatch(clearCommentItems());
     dispatch(requestComments());

--- a/src/explorer/DataExplorerActions.js
+++ b/src/explorer/DataExplorerActions.js
@@ -42,9 +42,8 @@ const convert = (json) => {
 };
 
 export const createQuerysetValueChanged = (config) => {
-  const url = window.xeniaHost + '/1.0/exec';
-
   return (dispatch, getState) => {
+    const url = getState().app.xeniaHost + '/1.0/exec';
 
     if (!getState().dataExplorer.loading) {
 
@@ -67,9 +66,9 @@ export const createQuerysetValueChanged = (config) => {
 
 export const fetchDataExplorationDataset = (field, queryParams) => {
   const queryParamString = queryParams ? convert(queryParams) : '';
-  const url = window.xeniaHost + '/1.0/exec/' + field + queryParamString;
 
   return (dispatch, getState) => {
+    const url = getState().app.xeniaHost + '/1.0/exec/' + field + queryParamString;
 
     if (!getState().dataExplorer.loading) {
 
@@ -102,9 +101,8 @@ const receiveControls = (querysets) => {
 };
 
 export const populateControlsReducer = () => {
-  const url = window.xeniaHost + '/1.0/query';
-
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const url = getState().app.xeniaHost + '/1.0/query';
     dispatch(requestControls());
 
     fetch(url, authXenia())

--- a/src/tags/TagActions.js
+++ b/src/tags/TagActions.js
@@ -28,9 +28,9 @@ var getInit = (body, method) => {
 
 // Functions
 export const getTags = () => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch(tagRequestStarted());
-    fetch(window.pillarHost + API_PREFIX + 'tags', getInit(null, 'GET'))
+    fetch(getState().app.pillarHost + API_PREFIX + 'tags', getInit(null, 'GET'))
       .then(
         response => response.json()
       )
@@ -40,14 +40,14 @@ export const getTags = () => {
 };
 
 export const storeTag = (tagName, tagDescription, index, oldValue) => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch(tagRequestStarted());
 
     var preparedTag = { 'name': tagName, 'description': tagDescription };
     if (typeof oldValue != 'undefined') {
       preparedTag['old_name'] = oldValue;
     }
-    fetch(window.pillarHost + API_PREFIX + 'tag', getInit(preparedTag))
+    fetch(getState().app.pillarHost + API_PREFIX + 'tag', getInit(preparedTag))
       .then(response => response.text())
       .then(responseText => {
         // Temporary fix, errors from pillar are not in JSON notation.
@@ -63,9 +63,9 @@ export const storeTag = (tagName, tagDescription, index, oldValue) => {
 };
 
 export const deleteTag = (tagName, tagDescription, index) => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch(tagRequestStarted());
-    fetch(window.pillarHost + API_PREFIX + 'tag', getInit({ 'name': tagName, 'description': tagDescription }, 'DELETE'))
+    fetch(getState().app.pillarHost + API_PREFIX + 'tag', getInit({ 'name': tagName, 'description': tagDescription }, 'DELETE'))
       .then(response => response)
       .then(deletedTag => dispatch(tagRequestSuccess(deletedTag, index, 'delete')))
       .catch(error => dispatch(tagRequestFailure(error)));
@@ -116,13 +116,11 @@ const allTagsRequestError = (err) => {
 };
 
 export const fetchAllTags = () => {
-  const url = window.pillarHost + '/api/tags';
-
   return (dispatch, getState) => {
     if (!getState().loadingTags) {
       dispatch(requestAllTags());
 
-      fetch(url)
+      fetch(getState().app.pillarHost + '/api/tags')
         .then(res => {
           return res.json();
         })

--- a/src/users/UsersActions.js
+++ b/src/users/UsersActions.js
@@ -35,8 +35,6 @@ const userUpsertRequestError = (err) => {
 };
 
 export const upsertUser = (preparedObject) => {
-  const url = window.pillarHost + '/api/user';
-
   return (dispatch, getState) => {
     if (!getState().upsertingUser) {
       dispatch(requestUserUpsert());
@@ -51,7 +49,7 @@ export const upsertUser = (preparedObject) => {
         body: JSON.stringify(preparedObject)
       };
 
-      fetch(url, init)
+      fetch(getState().app.pillarHost + '/api/user', init)
         .then(res => res.json())
         .then(json => {
           dispatch(receiveUpsertedUser(json));


### PR DESCRIPTION
## What does this PR do?

This replace calls to window.xeniaHost and window.pillarHost to getState().app.xeniaHost and getState().app.pillarHost since now we are storing that data inside the app state.

## How do I test this PR?

- Go to the tag manager
- It should show the tag list instead of throwing a `Tag action failed: SyntaxError: Unexpected token <` error.

@coralproject/frontend

getState().app.xeniaHost and getState().app.pillarHost because we are
now tracking the config as part of the app state.