### PR TITLE
Removed z-index from select handlers preventing to be on top of the

### DIFF
--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -303,8 +303,7 @@ var Slider = React.createClass({
   _buildHandleStyle: function (offset, i) {
     var style = {
       position: 'absolute',
-      willChange: this.state.index >= 0 ? this._posMinKey() : '',
-      zIndex: this.state.zIndices.indexOf(i) + 1
+      willChange: this.state.index >= 0 ? this._posMinKey() : ''
     };
     style[this._posMinKey()] = offset + 'px';
     return style;


### PR DESCRIPTION
## What does this PR do?

It fixes the `slider handler on top of a dropdown` issue:

![screen shot 2016-03-25 at 2 33 00 pm](https://cloud.githubusercontent.com/assets/165799/14051269/f998d92c-f297-11e5-93f9-f5448cea5aac.png)

## How do I test this PR?

- Go to the group-creator
- Select `Author` or `Section` from the first dropdown
- Open the second dropdown
- It should be clean, without handlers on top.

@coralproject/frontend

select.