### PR TITLE
parameterizing the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-# cat Dockerfile 
 FROM nginx:alpine
 COPY dist /usr/share/nginx/html
 COPY assets/nginx.conf /etc/nginx/
+
+COPY assets/config_from_env.sh /tmp/config_from_env.sh
+RUN chmod +x /tmp/config_from_env.sh
+
+CMD ["/tmp/config_from_env.sh"]

--- a/assets/config_from_env.sh
+++ b/assets/config_from_env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+cat > /usr/share/nginx/html/config.json <<EOL
+{
+  "xeniaHost":"${CAY_XENIAHOST:-}",
+  "pillarHost":"${CAY_PILLARHOST:-}",
+  "environment":"${CAY_ENVIRONMENT:-development}",
+  "brand":"${CAY_BRAND:-Tyrell Corporation}",
+  "googleAnalyticsId":"${CAY_GOOGLEANALYTICSID:-UA-XXXXXXXXXX}",
+  "requireLogin":${CAY_REQUIRELOGIN:-true},
+  "basicAuthorization":"${CAY_AUTH:-Basic 109340923j02i3jroi23jroi23ljf23f}"
+}
+EOL
+
+nginx -g "daemon off;"


### PR DESCRIPTION
## What does this PR do?

At present, the Dockerfile for Cay is missing a config.json; this branch creates one from environment variables. I was trying to get a working docker "cluster" running [via docker-compose](https://github.com/coralproject/reef/blob/master/docker/config.json), and it seemed like some of the components weren't quite parameterized yet.

## How do I test this PR?

Build with:
```docker build -t "coralproject/cay" .```

Then you can spin the built image up, passing in environment variables like so:
```
docker run -p 80:80 --name cayapp \
	-e "CAY_XENIAHOST=https://coraldemo.coralproject.net/xenia_api" \
	-e "CAY_PILLARHOST=https://coraldemo.coralproject.net/pillar_api" \
	-e "CAY_AUTH=Basic NmQ3MmU2ZGQtOTNkMC00NDEzLTliNGMtODU0NmQ0ZDM1MTRlOlBDeVgvTFRHWjhOdGZWOGVReXZObkpydm4xc2loQk9uQW5TNFpGZGNFdnc9" \
	coralproject/cay
```
(I've nabbed the working environment/config.json values from here: https://github.com/coralproject/reef/blob/master/docker/config.json)

....I realize I could be stepping on someone's behind-the-scene Docker work here, so feel free to ignore if there are other plans for how these things fit together!