### PR TITLE
fix date checking

### DIFF
--- a/src/filters/FiltersActions.js
+++ b/src/filters/FiltersActions.js
@@ -100,7 +100,7 @@ const parseFilterRanges = (ranges, filterState) => {
     const possibleDateValue = new Date(value);
     // if it's a Date, change the type
     console.log('parsed value', aggKey, value, possibleDateValue);
-    if (_.isDate(possibleDateValue) && !isNaN(possibleDateValue)) {
+    if (_.isString(value) && _.isDate(possibleDateValue) && !isNaN(possibleDateValue)) {
       value = possibleDateValue;
     }
 


### PR DESCRIPTION
## What?

I was trying to send in min/max ranges to `new Date()`, which actually turns out to be valid dates, much to my dismay. Since `Date`s are serialized in JSON as Z-strings, I just checked for the type of the input value.

## how to test

after ranges are fetched, the filter values should not all be dates.