### PR TITLE
Using react-ga errors. Close #173

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,11 +56,9 @@ class Root extends React.Component {
   constructor(props){
     super(props);
     ga.initialize(window.googleAnalyticsId, { debug: (process && process.env.NODE_ENV !== 'production') });
-    window.addEventListener('error', e => ga.event({
-      category: 'JS Error',
-      action: e.message,
-      label: e.stack
-    }));
+    window.addEventListener('error', e => ga.exception({
+      description: e.error.stack
+    }), false);
   }
 
   logPageView() {


### PR DESCRIPTION
## What does this PR do?

It uses `react-ga` new exceptions instead of regular events.
## How do I test this PR?

Throw an error on the client. It should send an error exception to google analytics.

@coralproject/frontend
