### PR TITLE
somehow the section call got lost in translation

### DIFF
--- a/src/filters/FiltersActions.js
+++ b/src/filters/FiltersActions.js
@@ -42,7 +42,11 @@ export const fetchSections = () => {
     dispatch(requestSections());
 
     /* xenia_package */
-
+    xenia().exec('dimension_section_list')
+      .then(json => dispatch(receiveSections(json)))
+      .catch(err => {
+        console.log('you failed to get the section list!', err);
+      });
   };
 };
 


### PR DESCRIPTION
## What?

The list of sections wasn't loading. It ended up being that when the translation to the xenia-driver-js happened, the section call was missed. This PR re-instates that code. #247 

## How to test

Go to the Search Creator page and select the dimension dropdown for Sections. The list of sections should populate.