### PR TITLE
correctly delete a search directly from Pillar

### DIFF
--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -39,7 +39,7 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    position: 'absolute',
+    position: 'fixed',
     zIndex: 100,
     top: 0,
     right: 0,

--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -469,10 +469,7 @@ export const deleteSearch = search => {
 
     dispatch({type: PILLAR_SEARCH_DELETE_INIT, search});
 
-    xenia().deleteQuery(search.query).then(data => {
-      console.info('query_set deleted from xenia', data);
-      return fetch(`${app.pillarHost}/api/search/${search.id}`, {method: 'DELETE'});
-    })
+    fetch(`${app.pillarHost}/api/search/${search.id}`, {method: 'DELETE'})
     .then(resp => {
       console.info('search deleted from pillar', resp);
       const newSearches = searches.searches.concat();

--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -367,7 +367,7 @@ const prepSearch = (filters, query, name, desc, tag, breakdown, specificBreakdow
   return {
     name, // the human-readable user-entered name
     description: desc, // user-entered string
-    query: query.name, // the name of the xenia query
+    querySet: _.cloneDeep(query), // the name of the xenia query
     tag, // unique name of live-tag
     filters: {
       values,

--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -367,7 +367,7 @@ const prepSearch = (filters, query, name, desc, tag, breakdown, specificBreakdow
   return {
     name, // the human-readable user-entered name
     description: desc, // user-entered string
-    querySet: _.cloneDeep(query), // the name of the xenia query
+    query: query.name, // the name of the xenia query
     tag, // unique name of live-tag
     filters: {
       values,


### PR DESCRIPTION
## What does this PR do?

Saved searches were not being deleted correctly since we're no longer saving the query to xenia. I also updated some styling so the delete modal is always on screen.

## How do I test this PR?

- go to the See All Saved Searches screen
- delete a search
- is the search now gone from the screen?

@coralproject/frontend

