### PR TITLE
Limit sortable filters by config

### DIFF
--- a/public/data_config.json
+++ b/public/data_config.json
@@ -23,7 +23,9 @@
       "template": "statistics.comments.<%= dimension %>.all.count",
       "description": "Total comments",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "First comment _ days ago",
@@ -32,7 +34,9 @@
       "template": "statistics.comments.<%= dimension %>.all.first",
       "description": "First comment _ days ago",
       "collection": "user_statistics",
-      "type": "intDateProximity"
+      "type": "intDateProximity",
+      "sortable": false,
+      "sortDesc": false
     },
     {
       "name": "Last comment _ days ago",
@@ -41,7 +45,9 @@
       "template": "statistics.comments.<%= dimension %>.all.last",
       "description": "Last comment _ days ago",
       "collection": "user_statistics",
-      "type": "intDateProximity"
+      "type": "intDateProximity",
+      "sortable": false,
+      "sortDesc": false
     },
 
 
@@ -53,7 +59,9 @@
       "template": "statistics.comments.<%= dimension %>.all.replied_count",
       "description": "Replies written",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": false,
+      "sortDesc": false
     },
     {
       "name": "Replies per Comment",
@@ -62,7 +70,9 @@
       "template": "statistics.comments.<%= dimension %>.all.replied_ratio",
       "description": "% comments that are replies",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": true,
+      "sortDesc": true
     },
 
 
@@ -73,7 +83,9 @@
       "template": "statistics.comments.<%= dimension %>.all.reply_count",
       "description": "Replies received",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Replied per Comment",
@@ -82,7 +94,9 @@
       "template": "statistics.comments.<%= dimension %>.all.reply_ratio",
       "description": "Replies received per comment",
       "collection": "user_statistics",
-      "type": "floatRange"
+      "type": "floatRange",
+      "sortable": true,
+      "sortDesc": true
     },
 
 
@@ -93,7 +107,9 @@
       "template": "statistics.comments.<%= dimension %>.all.word_count_average",
       "description": "Average words per post",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
 
 
@@ -105,7 +121,9 @@
       "template": "statistics.comments.<%= dimension %>.ratios.ModeratorDeleted",
       "description": "Percent moderator deleted",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Comments ModeratorDeleted",
@@ -114,7 +132,9 @@
       "template": "statistics.comments.<%= dimension %>.ModeratorDeleted.count",
       "description": "Number moderator deleted",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Last time ModeratorDeleted",
@@ -123,7 +143,9 @@
       "template": "statistics.comments.<%= dimension %>.ModeratorDeleted.last",
       "description": "Last time moderator deleted",
       "collection": "user_statistics",
-      "type": "intDateProximity"
+      "type": "intDateProximity",
+      "sortable": false,
+      "sortDesc": true
     },
     {
       "name": "Percent of ModeratorDeleted that were replies",
@@ -132,7 +154,9 @@
       "template": "statistics.comments.<%= dimension %>.ModeratorDeleted.replied_ratio",
       "description": "% of moderator deleted that were replies",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": false,
+      "sortDesc": true
     },
     {
       "name": "Percent of ModeratorDeleted that got replies",
@@ -141,7 +165,9 @@
       "template": "statistics.comments.<%= dimension %>.ModeratorDeleted.reply_ratio",
       "description": "% of moderator deleted that got replies",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": true,
+      "sortDesc": true
     },
 
 
@@ -155,7 +181,9 @@
       "template": "statistics.comments.<%= dimension %>.ratios.ModeratorApproved",
       "description": "Percent moderator approved",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Percent SystemFlagged",
@@ -164,7 +192,9 @@
       "template": "statistics.comments.<%= dimension %>.ratios.SystemFlagged",
       "description": "Percent system flagged",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Percent CommunityFlagged",
@@ -173,7 +203,9 @@
       "template": "statistics.comments.<%= dimension %>.ratios.CommunityFlagged",
       "description": "Percent community flagged",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Percent Untouched",
@@ -182,7 +214,9 @@
       "template": "statistics.comments.<%= dimension %>.ratios.Untouched",
       "description": "Percent untouched",
       "collection": "user_statistics",
-      "type": "percentRange"
+      "type": "percentRange",
+      "sortable": false,
+      "sortDesc": true
     },
 
 
@@ -196,7 +230,9 @@
       "template": "statistics.comments.<%= dimension %>.all.first",
       "description": "First comment between",
       "collection": "user_statistics",
-      "type": "dateRange"
+      "type": "dateRange",
+      "sortable": false,
+      "sortDesc": true
     },
     {
       "name": "Last comment between",
@@ -205,7 +241,9 @@
       "template": "statistics.comments.<%= dimension %>.all.last",
       "description": "Last comment between",
       "collection": "user_statistics",
-      "type": "dateRange"
+      "type": "dateRange",
+      "sortable": false,
+      "sortDesc": true
     },
 
 
@@ -216,7 +254,9 @@
       "template": "statistics.actions.performed.likes.count",
       "description": "The number of likes performed by the user",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Likes received",
@@ -225,7 +265,9 @@
       "template": "statistics.actions.received.likes.count",
       "description": "The number of likes received by the user",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Flags performed",
@@ -234,7 +276,9 @@
       "template": "statistics.actions.performed.flags.count",
       "description": "The number of flags performed by the user",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     },
     {
       "name": "Flags received",
@@ -243,7 +287,9 @@
       "template": "statistics.actions.received.flags.count",
       "description": "The number of flags received by the user",
       "collection": "user_statistics",
-      "type": "intRange"
+      "type": "intRange",
+      "sortable": true,
+      "sortDesc": true
     }
   ]
 }

--- a/src/users/UserList.jsx
+++ b/src/users/UserList.jsx
@@ -134,20 +134,15 @@ export default class UserList extends React.Component {
     </p>);
 
     const {filters} = this.props;
-    var userListContent = this.props.users.length ? this.getUserList(this.props.users) : noUsersMessage;
+    const userListContent = this.props.users.length ? this.getUserList(this.props.users) : noUsersMessage;
 
     // get a list of only the sortable filters
-    var sortableFilters = [];
-    for (var i in filters.filterList) {
-      var filter = filters[filters.filterList[i]]; // we're working with a list of keys to the root of the props
-      if (filter.sortable) {
-        sortableFilters.push({
-          label: filter.description,
-          value: filters.filterList[i] // passing the key of the filter here
-        })
-      }
-    }
-
+    const sortableFilters = filters.filterList
+      .filter(filter => filters[filter].sortable)
+      .map(filter => ({
+        label: filters[filter].description,
+        value: filter
+      }));
 
     return (
       <div style={ [ styles.base, this.props.style ] }>

--- a/src/users/UserList.jsx
+++ b/src/users/UserList.jsx
@@ -135,9 +135,19 @@ export default class UserList extends React.Component {
 
     const {filters} = this.props;
     var userListContent = this.props.users.length ? this.getUserList(this.props.users) : noUsersMessage;
-    var sortableFilters = filters.filterList.map(filter => {
-      return {label: filters[filter].description, value: filter};
-    });
+
+    // get a list of only the sortable filters
+    var sortableFilters = [];
+    for (var i in filters.filterList) {
+      var filter = filters[filters.filterList[i]]; // we're working with a list of keys to the root of the props
+      if (filter.sortable) {
+        sortableFilters.push({
+          label: filter.description,
+          value: filters.filterList[i] // passing the key of the filter here
+        })
+      }
+    }
+
 
     return (
       <div style={ [ styles.base, this.props.style ] }>


### PR DESCRIPTION
## What does this PR do?

Some of the sort filters didn't make sense as sorts.  To be able to control this, added "sortable" and "sortDescending" config flags to the filters.  These flags are now used to limit which filters appear in the sort dropdown on the create screen.

## How do I test this PR?

Set which filters you want to be sortable in data_config.json.  Check to see that only they are sort options on create.

@coralproject/frontend

