### PR TITLE
Trust save edit search

### DIFF
--- a/src/app/SearchCreator.jsx
+++ b/src/app/SearchCreator.jsx
@@ -122,7 +122,7 @@ export default class SearchCreator extends Component {
             visible={this.props.searches.savingSearch || !!this.props.searches.recentSavedSearch}>
             {
               this.props.searches.recentSavedSearch ?
-              (<Link style={styles.searchDetail} to={`/saved-search/${this.props.searches.recentSavedSearch.name}`}>
+              (<Link style={styles.searchDetail} to={`/saved-search/${this.props.searches.recentSavedSearch.id}`}>
                 View Your Saved Search [{this.props.searches.recentSavedSearch.name}] →
               </Link>) :
               'Saving Search...'

--- a/src/app/SearchDetail.jsx
+++ b/src/app/SearchDetail.jsx
@@ -1,135 +1,76 @@
 import React from 'react';
 import Radium from 'radium';
 import {connect} from 'react-redux';
-import {userSelected} from 'users/UsersActions';
-import {fetchQueryset} from 'search/SearchActions';
-import {fetchCommentsByUser} from 'comments/CommentsActions';
+import {fetchQueryset, fetchSearch} from 'search/SearchActions';
 import {xenia} from 'app/AppActions';
-import _ from 'lodash';
 
 import Page from 'app/layout/Page';
 import ContentHeader from 'components/ContentHeader';
 import UserList from 'users/UserList';
-import UserDetail from 'users/UserDetail';
 import { clearUserList } from 'search/SearchActions';
 
-// const mapStateToProps = state => {
-//   return {
-//     searches: state.searches,
-//     users: state.users,
-//     comments: state.comments
-//   };
-// };
+const mapStateToProps = state => {
+  return {
+    searches: state.searches,
+    users: state.users,
+    comments: state.comments
+  };
+};
 
-// @connect(mapStateToProps)
+@connect(mapStateToProps)
 @Radium
 export default class SearchDetail extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      queryset: {
 
-      },
-      users: [],
-      count: 0,
-      page: 0,
-      loading: false,
-      error: null,
-      selectedUser: null,
-      comments: [],
-      sortBy: null
-    };
+  constructor (props) {
+    super(props);
+    this.state = {usersFetchedOnce: false};
   }
 
   componentWillMount() {
-    this.fetchUsers();
+    this.props.dispatch(clearUserList());
+    console.log('about to look up search', this.props.params.id);
+    this.props.dispatch(fetchSearch(this.props.params.id));
+    // this.fetchUsers();
   }
 
-  fetchUsers() {
-    this.setState({loading: true, error: null});
-    xenia()
-      .exec(this.props.params.name, {
-        limit: 20,
-        skip: 20 * this.state.page,
-        sort: this.state.sortBy
-      })
-      .then((res) => {
-        this.setState({
-          queryset: res.results[1],
-          users: this.state.users.concat(res.results[0].Docs),
-          count: res.results[1].Docs[0].count,
-          loading: false,
-          error: null
-        });
-      })
-      .catch((err) => {
-        console.log(err);
-        this.setState({
-          loading: false,
-          error: err
-        });
-      });
+  componentWillReceiveProps(nextProps) {
+    if (!this.state.usersFetchedOnce && nextProps.searches.activeSavedSearch) {
+      this.setState({usersFetchedOnce: true});
+      this.props.dispatch(fetchQueryset(nextProps.searches.activeSavedSearch.query));
+    }
   }
 
-  fetchComments(user) {
-    xenia()
-      .exec('comments_by_user', {user_id: user._id})
-        .then((data) => {
-          console.log(data);
-
-          this.setState({
-            selectedUser: user,
-            comments: data.results[0].Docs
-          });
-        })
-        .catch((err) =>
-          console.log(err)
-        );
-  }
-
-  // updateUser(user) {
-  //   this.props.dispatch(userSelected(user));
-  //   this.props.dispatch(fetchCommentsByUser(user._id));
-  // }
-
-  onPagination() {
-    this.setState({page: this.state.page + 1 });
-    this.fetchUsers();
-  }
-
-  onSortChanged(filter) {
-    this.setState({
-      sortBy: `statistics.comments.all.all.${filter.field}`,
-      page: 0,
-      selectedUser: null,
-      users: []
-    });
-    this.fetchUsers();
+  onPagination(page = 0) {
+    this.props.dispatch(fetchQueryset(this.props.searches.activeSavedSearch.query, page));
   }
 
   render() {
-    const {queryset, users, count, selectedUser, comments} = this.state;
-    const search = queryset;
-    return (
 
+    const search = this.props.searches.activeSavedSearch;
+
+    return (
       <Page>
-        <ContentHeader title={search.Name}/>
-        <p style={styles.description}>Description: {search.description}</p>
-        <div style={styles.base}>
-          <UserList
-            onPagination={this.onPagination.bind(this)}
-            userSelected={this.fetchComments.bind(this)}
-            loadingQueryset={this.state.loading}
-            onSortChanged={this.onSortChanged.bind(this)}
-            total={count}
-            style={styles.userList}
-            users={users} />
-          <UserDetail
-            commentsLoading={false}
-            user={selectedUser}
-            comments={comments}
-            style={styles.userDetail} />
-        </div>
+        {
+          this.props.searches.loadingSavedSearch ?
+            <p>Loading Saved Search...</p> :
+            null
+        }
+        {
+          search ?
+          <div>
+            <ContentHeader title={search.name}/>
+            <p style={styles.description}>Description: {search.description}</p>
+            <div style={styles.base}>
+              <UserList
+                onPagination={this.onPagination.bind(this)}
+                loadingQueryset={this.state.loading}
+                style={styles.userList}
+                users={this.props.searches.users} />
+            </div>
+          </div> :
+          null
+        }
+
       </Page>
     );
   }

--- a/src/app/SearchDetail.jsx
+++ b/src/app/SearchDetail.jsx
@@ -62,6 +62,7 @@ export default class SearchDetail extends React.Component {
             <p style={styles.description}>Description: {search.description}</p>
             <div style={styles.base}>
               <UserList
+                total={this.props.searches.userCount}
                 onPagination={this.onPagination.bind(this)}
                 loadingQueryset={this.state.loading}
                 style={styles.userList}

--- a/src/app/SearchEditor.jsx
+++ b/src/app/SearchEditor.jsx
@@ -20,7 +20,6 @@ import ContentHeader from 'components/ContentHeader';
 import UserFilters from 'filters/UserFilters';
 import FaFloopyO from 'react-icons/lib/fa/floppy-o';
 import UserList from 'users/UserList';
-import UserDetail from 'users/UserDetail';
 import TextField from 'components/forms/TextField';
 import Clauses from 'search/Clauses';
 
@@ -118,13 +117,6 @@ export default class SearchEditor extends React.Component {
                     loadingQueryset={this.props.searches.loadingQueryset}
                     users={this.props.searches.users}
                     userSelected={this.updateUser.bind(this)} />
-                  <UserDetail
-                    breakdown={this.props.filters.breakdownEdit}
-                    specificBreakdown={this.props.filters.specificBreakdownEdit}
-                    commentsLoading={this.props.comments.loading}
-                    user={this.props.users.selectedUser}
-                    comments={this.props.comments.items}
-                    style={styles.userDetail} />
                 </div>
               </div>
             </div>
@@ -147,11 +139,6 @@ const styles = {
     height: 900,
     display: 'flex',
     clear: 'both'
-  },
-  userDetail: {
-    flex: 2,
-    paddingLeft: 40,
-    height: 900
   },
   rightPanel: {
     flex: 1

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ class Root extends React.Component {
             {/***** Trust Search Routes *****/}
             <Route path="search-creator" component={SearchCreator} />
             <Route path="saved-searches" component={SeeAllSearches}/>
-            <Route path="saved-search/:name" component={SearchDetail} />
+            <Route path="saved-search/:id" component={SearchDetail} />
             <Route path="edit-search/:id" component={SearchEditor} />
 
 

--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -321,7 +321,7 @@ export const saveQueryFromState = (queryName, desc, tag) => {
     dispatch({type: PILLAR_SEARCH_SAVE_INIT, query: state.searches.activeQuery});
 
     console.log('about to doPutQuery');
-    doPutQuery(dispatch, state, queryName, desc, tag);
+    saveSearchToPillar(dispatch, state, queryName, desc, tag);
   };
 };
 
@@ -352,7 +352,7 @@ const createQueryForSave = (query, name, desc) => {
 };
 
 // create the body of request to save a Search to Pillar
-const prepSearch = (filters, query, name, desc, tag, breakdown, specificBreakdown) => {
+const prepSearchForPillar = (filters, query, name, desc, tag, breakdown, specificBreakdown) => {
 
   let values = _.compact(_.map(filters, f => {
     // this will return the ENTIRE filter if only the min OR max was changed.
@@ -367,7 +367,7 @@ const prepSearch = (filters, query, name, desc, tag, breakdown, specificBreakdow
   return {
     name, // the human-readable user-entered name
     description: desc, // user-entered string
-    query: query.name, // the name of the xenia query
+    querySet: query, // the full xenia queryset (without the name)
     tag, // unique name of live-tag
     filters: {
       values,
@@ -387,16 +387,15 @@ the filters object only stores non-default values and the dimension breakdowns
 */
 const doPutQuery = (dispatch, state, name, desc, tag) => {
 
-  const {breakdown, specificBreakdown} = state.filters;
-  const query = createQueryForSave(state.searches.activeQuery, name, desc);
 
   xenia(query)
     .saveQuery()
     .then(() => { // if response.status < 400
       dispatch({type: QUERYSET_SAVE_SUCCESS, name: query.name});
 
-      const filters = state.filters.filterList.map(key => state.filters[key]);
-      const body = prepSearch(filters, query, name, desc, tag, breakdown, specificBreakdown);
+        const filters = state.filters.filterList.map(key => state.filters[key]);
+
+
 
       fetch(`${state.app.pillarHost}/api/search`, {method: 'POST', body: JSON.stringify(body)})
         .then(resp => resp.json())
@@ -412,6 +411,54 @@ const doPutQuery = (dispatch, state, name, desc, tag) => {
       dispatch({type: QUERYSET_SAVE_FAILED, error});
     });
 };
+
+
+const saveQuerySetToXenia = (state, search) => {
+
+  // build the queryset from state
+  const query = createQueryForSave(state.searches.activeQuery, name, desc);
+
+  // we are using a pillar generated queryset name, so
+  //   set the query name from the search, which has
+  //   been returned from pillar/api/search POST
+  query.name = search.query;
+
+  console.log("save search to xenia", query);
+
+  xenia(query)
+    .saveQuery()
+    .then(() => { // if response.status < 400
+      dispatch({type: QUERYSET_SAVE_SUCCESS, name: query.name});
+
+
+    }).catch(error => {
+      dispatch({type: QUERYSET_SAVE_FAILED, error});
+    });
+
+
+}
+
+const saveSearchToPillar = (dispatch, state, name, desc, tag) => {
+
+  const {breakdown, specificBreakdown} = state.filters;
+  const query = createQueryForSave(state.searches.activeQuery, name, desc);
+  const filters = state.filters.filterList.map(key => state.filters[key]);
+
+  const body = prepSearchForPillar(filters, query, name, desc, tag, breakdown, specificBreakdown);
+
+  fetch(`${state.app.pillarHost}/api/search`, {method: 'POST', body: JSON.stringify(body)})
+    .then(resp => resp.json())
+    .then(search => {
+      // do something with savedSearch?
+      dispatch({type: PILLAR_SEARCH_SAVE_SUCCESS, search});
+      dispatch(saveQuerySetToXenia(state, search));
+    })
+    .catch(error => {
+      dispatch({type: PILLAR_SEARCH_SAVE_FAILED, error});
+    });
+}
+
+
 /* xenia_package */
 const doMakeQueryFromStateAsync = _.debounce((query, dispatch, app, replace)=>{
   dispatch(requestQueryset());
@@ -447,7 +494,7 @@ export const updateSearch = staleSearch => {
       });
 
       // update search in pillar
-      const body = prepSearch(editFilters, query, name, description, tag, breakdownEdit, specificBreakdownEdit);
+      const body = prepSearchForPillar(editFilters, query, name, description, tag, breakdownEdit, specificBreakdownEdit);
 
       // append the id for update mode
       body.id = staleSearch.id;

--- a/src/search/SearchReducer.js
+++ b/src/search/SearchReducer.js
@@ -4,6 +4,9 @@ const initialState = {
   loading: false,
   loadingQueryset: false,
   activeQuery: null,
+  loadingSavedSearch: false,
+  activeSavedSearch: null,
+  savedSearchError: '',
   recentSavedSearch: null,
   updatingSearch: false,
   editableSearch: null, // this search controls the SearchEditor component
@@ -24,6 +27,25 @@ const searches = (state = initialState, action) => {
       ...state,
       loadingQueryset: false,
       showTheError: `failed to load ${action.querysetName}`
+    };
+
+  case types.PILLAR_SEARCH_REQUEST:
+    return {
+      ...state,
+      loadingSavedSearch: true,
+      activeSavedSearch: null,
+      savedSearchError: ''
+    };
+
+  case types.PILLAR_SEARCH_SUCCESS:
+    return {...state, loadingSavedSearch: false, activeSavedSearch: action.search};
+
+  case types.PILLAR_SEARCH_FAILED:
+    return {
+      ...state,
+      loadingSavedSearch: false,
+      activeSavedSearch: null,
+      savedSearchError: action.error
     };
 
   case types.CREATE_QUERY: // store the query so it can be easily saved to pillar


### PR DESCRIPTION
## What?

Everything was messed up on the saved search page. Now you should be able to view one. @jde and I did some work to store searches in Pillar *then* in xenia so things make more sense. This PR removes the xenia code from the SearchDetail component and uses the state again.

## How to test

- create a saved search
- click on the Status Bar newly created search thing
- you should be able to see search results from your search