### PR TITLE
Added default search sort

### DIFF
--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -308,6 +308,9 @@ export const makeQueryFromState = (type, page = 0, replace = false, editMode = f
       const field = _.template(sortBy[0])
         ({dimension: `${breakdown}${specificBreakdown ? `.${specificBreakdown}` : ''}`});
       x.sort([field, sortBy[1]]);
+    } else {
+      // default sorting
+      x.sort(['statistics.comments.all.all.count', -1]);
     }
     x.skip(page * pageSize).limit(pageSize)
       .include(['name', 'avatar', 'statistics.comments']);


### PR DESCRIPTION
## What does this PR do?

- Applying total comments as the default sorting criteria

## How do I test this PR?

- Open the search creator

@coralproject/frontend

