### PR TITLE
faster responses, more clarity on empty result set

### DIFF
--- a/src/app/SearchCreator.jsx
+++ b/src/app/SearchCreator.jsx
@@ -116,6 +116,8 @@ export default class SearchCreator extends Component {
     const {dispatch} = this.props;
 
     dispatch(userSelected(null));
+    // this must be here because when a filter is changed, ALL results are stale
+    dispatch(clearUserList());
     dispatch(filterChanged(fieldName, {[attr]: val}));
     dispatch(makeQueryFromState('user', 0, true));
   }

--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -189,12 +189,13 @@ export const requestQuerysetFailure = (err) => {
 };
 
 export const receiveQueryset = (data, replace) => {
-  console.log('action receiveQueryset', data, replace);
+  const userCount = _.has(data, 'results.1.Docs.0.count') ? data.results[1].Docs[0].count : 0;
+
   return {
     type: QUERYSET_RECEIVED,
     data,
     replace,
-    userCount: data.results[1].Docs[0].length
+    userCount
   };
 };
 

--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -476,10 +476,7 @@ const doMakeQueryFromStateAsync = _.debounce((query, dispatch, app, replace) => 
   dispatch(createQuery(query._data));
 
   query.exec()
-    .then(json => {
-      console.log('receiveQueryset', json, replace);
-      dispatch(receiveQueryset(json, replace));
-    })
+    .then(json => dispatch(receiveQueryset(json, replace)))
     .catch(() => {});
 }, 250);
 

--- a/src/search/SearchReducer.js
+++ b/src/search/SearchReducer.js
@@ -2,7 +2,7 @@ import * as types from 'search/SearchActions';
 
 const initialState = {
   loading: false,
-  loadingQueryset: false,
+  loadingQueryset: true,
   activeQuery: null,
   loadingSavedSearch: false,
   activeSavedSearch: null,

--- a/src/users/UserList.jsx
+++ b/src/users/UserList.jsx
@@ -142,8 +142,7 @@ export default class UserList extends React.Component {
     const { user, users, comments } = this.props;
 
     var noUsersMessage = (<p style={ styles.noUsers }>
-      No users loaded yet,<br />
-      create a filter on the left to load users.
+      Zero users found...<br />Please widen your search.
     </p>);
 
     const {filters} = this.props;
@@ -166,7 +165,7 @@ export default class UserList extends React.Component {
               <Spinner />
             </div> :
             <Heading size='medium'>
-              <span style={styles.groupHeader}>{ window.L.t('results') }</span> ({this.props.total || '#'} {this.props.total !== 1 ? window.L.t('users') : window.L.t('user')})
+              <span style={styles.groupHeader}>{ window.L.t('results') }</span> ({this.props.total} {this.props.total !== 1 ? window.L.t('users') : window.L.t('user')})
             </Heading>
           }
           <div style={styles.sort}>


### PR DESCRIPTION
## What does this PR do?

This PR does a couple of things
- fix issue where it was very unclear that 0 users was returned from a search
- reduce size of response from xenia by being more specific in the `include()` step in xenia driver (~99.6% reduction)

## How do I test this PR?

- go to search create page
- search should render faster and on a crappier connection
- enter 7 into the "first commented x days ago" filter
- count should show 0 and prompt should be more clear.

@coralproject/frontend
