### PR TITLE
Form list design updates

### DIFF
--- a/src/app/FormList.jsx
+++ b/src/app/FormList.jsx
@@ -21,6 +21,8 @@ import TableCell from 'components/tables/TableCell';
 import Tab from 'components/tabs/Tab';
 import Tabs from 'components/tabs/Tabs';
 
+import ButtonGroup from 'components/ButtonGroup';
+
 // Forms, Widgets, Submissions
 
 @connect(({ forms }) => ({ forms }))
@@ -46,7 +48,6 @@ export default class FormList extends React.Component {
 
   onConfirmClick() {
     var formToDelete = this.state.formToDelete;
-    console.log("Form to delete", formToDelete);
     this.setState({ confirmFormName: '', showConfirmDialog: false, tagToDelete: null });
     this.props.dispatch(deleteForm(...formToDelete));
   }
@@ -98,11 +99,17 @@ export default class FormList extends React.Component {
           <Link to="forms/create"><Button category="info">Create <MdForum /></Button></Link>
         </ContentHeader>
 
+        <ButtonGroup initialActiveIndex={0} behavior="radio">
+          <Button>Open</Button>
+          <Button>Closed</Button>
+        </ButtonGroup>
+
+
         <Tabs initialSelectedIndex={0} style={styles.tabs}>
-          <Tab title="Active">
+          <Tab title="Open">
             {this.renderTable(groups.active || groups[''])}
           </Tab>
-          <Tab title="Inactive">
+          <Tab title="Closed">
             {this.renderTable(groups.inactive || [])}
           </Tab>
         </Tabs>

--- a/src/app/FormList.jsx
+++ b/src/app/FormList.jsx
@@ -6,7 +6,7 @@ import MdDelete from 'react-icons/lib/md/delete';
 import _ from 'lodash';
 import MdForum from 'react-icons/lib/md/forum';
 
-import { deleteForm, fetchForms } from 'forms/FormActions';
+import { deleteForm, fetchForms, updateFormStatus } from 'forms/FormActions';
 import settings from 'settings';
 
 import Page from 'app/layout/Page';
@@ -28,6 +28,11 @@ import ButtonGroup from 'components/ButtonGroup';
 @connect(({ forms }) => ({ forms }))
 @Radium
 export default class FormList extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {displayMode: 'open'};
+  }
 
   static contextTypes = {
     router: PropTypes.object.isRequired
@@ -88,10 +93,14 @@ export default class FormList extends React.Component {
     );
   }
 
+  setDisplayMode(displayMode) {
+    this.setState({displayMode});
+  }
+
   render() {
 
     const forms = this.props.forms.formList.map(id => this.props.forms[id]);
-    const groups = _.groupBy(forms, 'status');
+    const visibleForms = forms.filter(form => form.status === this.state.displayMode);
 
     return (
       <Page>
@@ -100,19 +109,11 @@ export default class FormList extends React.Component {
         </ContentHeader>
 
         <ButtonGroup initialActiveIndex={0} behavior="radio">
-          <Button>Open</Button>
-          <Button>Closed</Button>
+          <Button onClick={this.setDisplayMode.bind(this, 'open')}>Open</Button>
+          <Button onClick={this.setDisplayMode.bind(this, 'closed')}>Closed</Button>
         </ButtonGroup>
 
-
-        <Tabs initialSelectedIndex={0} style={styles.tabs}>
-          <Tab title="Open">
-            {this.renderTable(groups.active || groups[''])}
-          </Tab>
-          <Tab title="Closed">
-            {this.renderTable(groups.inactive || [])}
-          </Tab>
-        </Tabs>
+        {this.renderTable(visibleForms)}
 
         {
           this.state.showConfirmDialog ?

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -57,8 +57,8 @@ export default class FormChrome extends React.Component {
     const name = _.has(this.props, 'form.header.title') ? this.props.form.header.title : 'Untitled Form';
 
     const statusOptions = [
-      {label: 'Active', value: 'active'},
-      {label: 'Inactive', value: 'inactive'}
+      {label: 'Open', value: 'open'},
+      {label: 'Closed', value: 'closed'}
     ];
 
     return (

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -50,7 +50,10 @@ const styles = {
   base: {
     transition: 'all 300ms',
     backgroundColor: '#fff',
-    borderRadius: 4,
+    borderTopLeftRadius: 4, // I know this could be one property
+    borderTopRightRadius: 4, // this is here to supress Radium warnings
+    borderBottomRightRadius: 4,
+    borderBottomLeftRadius: 4,
     borderStyle: 'solid',
     borderWidth: 1,
     borderColor: '#ccc',

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -99,6 +99,15 @@ const styles = {
       borderColor: color(settings.primaryColor).darken(0.2).hexString()
     }
   },
+  brand: {
+    backgroundColor: settings.brandColor,
+    borderColor: color(settings.brandColor).darken(0.1).hexString(),
+    color: '#fff',
+    ':hover': {
+      backgroundColor: color(settings.brandColor).darken(0.1).hexString(),
+      borderColor: color(settings.brandColor).darken(0.2).hexString()
+    }
+  },
   success: {
     backgroundColor: settings.successColor,
     borderColor: color(settings.successColor).darken(0.1).hexString(),

--- a/src/components/ButtonGroup.jsx
+++ b/src/components/ButtonGroup.jsx
@@ -13,6 +13,7 @@ export default class ButtonGroup extends React.Component {
     // if the {behavior} is "radio", there is only one active button at a time
     // if the {behavior} is "checkbox", there could be more than one
     initialActiveIndex: PropTypes.number.isRequired,
+    initialCheckedIndexes: PropTypes.arrayOf(PropTypes.number), // if a checkbox
     behavior: PropTypes.oneOf(['default', 'radio', 'checkbox'])
   }
 

--- a/src/components/ButtonGroup.jsx
+++ b/src/components/ButtonGroup.jsx
@@ -61,7 +61,6 @@ export default class ButtonGroup extends React.Component {
         child,
         {
           onClick: () => {
-            console.log('I clicked a button');
             this.setActiveIndex(i);
             // call the click handler on the old button if it exists
             child.props.onClick && child.props.onClick.call(child);

--- a/src/components/ButtonGroup.jsx
+++ b/src/components/ButtonGroup.jsx
@@ -17,10 +17,6 @@ export default class ButtonGroup extends React.Component {
     behavior: PropTypes.oneOf(['default', 'radio', 'checkbox'])
   }
 
-  getActiveStyle() {
-    console.log('getActiveStyle');
-  }
-
   setActiveIndex(activeIndex) {
     this.setState({activeIndex});
   }
@@ -75,15 +71,9 @@ export default class ButtonGroup extends React.Component {
 
   render() {
     return (
-      <div style={[styles.base, this.props.style]}>
+      <div style={this.props.style}>
         {this.layoutButtons(this.props.children)}
       </div>
     );
   }
 }
-
-const styles = {
-  base: {
-
-  }
-};

--- a/src/components/ButtonGroup.jsx
+++ b/src/components/ButtonGroup.jsx
@@ -62,7 +62,7 @@ export default class ButtonGroup extends React.Component {
             // call the click handler on the old button if it exists
             child.props.onClick && child.props.onClick.call(child);
           },
-          style: [ getCorners(i, children.length)],
+          style: getCorners(i, children.length),
           category: i === this.state.activeIndex ? 'brand' : 'default'
         }
       );

--- a/src/components/ButtonGroup.jsx
+++ b/src/components/ButtonGroup.jsx
@@ -1,0 +1,89 @@
+import React, {PropTypes} from 'react';
+import Radium from 'radium';
+
+@Radium
+export default class ButtonGroup extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {activeIndex: props.initialActiveIndex || 0};
+  }
+
+  static propTypes = {
+    // if the {behavior} is "radio", there is only one active button at a time
+    // if the {behavior} is "checkbox", there could be more than one
+    initialActiveIndex: PropTypes.number.isRequired,
+    behavior: PropTypes.oneOf(['default', 'radio', 'checkbox'])
+  }
+
+  getActiveStyle() {
+    console.log('getActiveStyle');
+  }
+
+  setActiveIndex(activeIndex) {
+    this.setState({activeIndex});
+  }
+
+  layoutButtons(children) {
+
+    function getCorners (i, len) {
+      let styleObj = {};
+      if (len === 1) { // there is only one button
+        // nothin'
+      } else if (i === 0) {
+        styleObj = {
+          borderTopRightRadius: 0,
+          borderBottomRightRadius: 0
+        };
+      } else if (i === len - 1) {
+        styleObj = {
+          borderTopLeftRadius: 0,
+          borderBottomLeftRadius: 0,
+          borderLeft: 'none'
+        };
+      } else { // one of the middle buttons
+        styleObj = {
+          borderRadius: 0,
+          borderLeft: 'none'
+        };
+      }
+
+      return styleObj;
+    }
+
+    return React.Children.map(children, (child, i) => {
+
+      if (child.props.category) {
+        console.warn('weird things might happen if you have a "category" property set in a ButtonGroup');
+      }
+
+      return React.cloneElement(
+        child,
+        {
+          onClick: () => {
+            console.log('I clicked a button');
+            this.setActiveIndex(i);
+            // call the click handler on the old button if it exists
+            child.props.onClick && child.props.onClick.call(child);
+          },
+          style: [ getCorners(i, children.length)],
+          category: i === this.state.activeIndex ? 'brand' : 'default'
+        }
+      );
+    });
+  }
+
+  render() {
+    return (
+      <div style={[styles.base, this.props.style]}>
+        {this.layoutButtons(this.props.children)}
+      </div>
+    );
+  }
+}
+
+const styles = {
+  base: {
+
+  }
+};

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -268,7 +268,7 @@ export const saveForm = (form, widgets) => {
   data.steps[0].widgets = widgets;
 
   // FIXME: remove this hotfix
-  data.status = form.settings.isActive ? 'active' : 'inactive';
+  data.status = form.settings.isActive ? 'open' : 'closed';
 
   return (dispatch, getState) => {
 


### PR DESCRIPTION
## What does this PR do?

Update the `FormList` component to only show forms as Open or Closed as per this issue https://github.com/coralproject/cay/issues/352

## How do I test this PR?

- go to the Form List page
- there should be a radio button group (the newly minted `ButtonGroup` component)
- you should be able to toggle back and forth between states and see the list update

@coralproject/frontend
