### PR TITLE
Fixed breakdown selection

### DIFF
--- a/src/search/SearchActions.js
+++ b/src/search/SearchActions.js
@@ -316,8 +316,11 @@ export const makeQueryFromState = (type, page = 0, replace = false, editMode = f
       x.sort(['statistics.comments.all.all.count', -1]);
     }
 
+    // statistics.comments.all.all is always needed
+    const breakdownFields = specificBreakdown !== '' ?
+      `statistics.comments.${breakdown}.${specificBreakdown}` : null;
     x.skip(page * pageSize).limit(pageSize)
-      .include(['name', 'avatar', ...dbFields]);
+      .include(['name', 'avatar', 'statistics.comments.all', breakdownFields]);
 
     // get the counts
     addMatches(x.addQuery());


### PR DESCRIPTION
## What does this PR do?

Fixes the breakdown select issue by broading the search. We always need to get the `statistics.comments.all.all` field and if the specificBreakdown is selected we should get `statistics.comments.breakdown.specificBreakdown` data too.

## How do I test this PR?

- Go to search creation
- Select an author or section
- It should get the data and work

@coralproject/frontend

