### PR TITLE
First pass at Status dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-icon-base": "^1.0.0",
     "react-icons": "^2.0.1",
     "react-infinite": "^0.9.2",
+    "react-onclickoutside": "^5.3.2",
     "react-redux": "^4.4.5",
     "react-router": "^2.0.0-rc5",
     "react-select": "^1.0.0-beta13",

--- a/src/app/Dashboard.jsx
+++ b/src/app/Dashboard.jsx
@@ -4,7 +4,8 @@ import Radium from 'radium';
 import Page from './Page';
 import Card from '../components/cards/Card';
 
-import DatePicker from 'react-datepicker';
+// https://github.com/Hacker0x01/react-datepicker/issues/483
+import DatePicker from 'react-datepicker/lib/datepicker';
 import moment from 'moment';
 
 // this doesn't seem wise, but copying the file to /css seems worse.

--- a/src/app/FormCreate.jsx
+++ b/src/app/FormCreate.jsx
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import Radium from 'radium';
 import { connect } from 'react-redux';
 
-import { createEmpty, saveForm } from 'forms/FormActions';
+import { createEmpty } from 'forms/FormActions';
 import Page from 'app/layout/Page';
 
 import FormBuilder from 'forms/FormBuilder.js';

--- a/src/app/FormEdit.jsx
+++ b/src/app/FormEdit.jsx
@@ -58,9 +58,8 @@ export default class FormEdit extends Component {
     });
   }
 
-  updateFormStatus(option) {
-    console.log(this.props);
-    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, option.value));
+  updateFormStatus(value) {
+    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
   }
 
   render() {

--- a/src/app/SubmissionGallery.jsx
+++ b/src/app/SubmissionGallery.jsx
@@ -89,8 +89,8 @@ export default class SubmissionGallery extends React.Component {
     );
   }
 
-  updateFormStatus(option) {
-    this.props.dispatch(updateFormStatus(this.props.activeForm, option.value));
+  updateFormStatus(value) {
+    this.props.dispatch(updateFormStatus(this.props.activeForm, value));
   }
 
   getAttributionFields(form) {

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -48,8 +48,8 @@ export default class SubmissionList extends Component {
     this.props.dispatch(updateSubmission({ bookmarked }));
   }
 
-  updateFormStatus(option) {
-    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, option.value));
+  updateFormStatus(value) {
+    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
   }
 
   render() {
@@ -148,7 +148,6 @@ class SubmissionDetail extends Component {
     return (
       <div style={styles.detail.container}>
         {this.renderAuthorDetail()}
-        {this.renderAnswers()}
       </div>
     );
   }
@@ -269,7 +268,7 @@ class SubmissionDetail extends Component {
             <h2 style={styles.detail.authorTitle}>Submission Author Information</h2>
             <div style={styles.detail.authorDetailsContainer}>
               <div style={styles.detail.authorDetailsColumn}>
-                { authorDetails.map(detail => <div>{detail.label}: {detail.answer}</div>) }
+                { authorDetails.map((detail, i) => <div key={i}>{detail.label}: {detail.answer}</div>) }
               </div>
             </div>
           </div>

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -83,6 +83,7 @@ export default class FormChrome extends React.Component {
       border: '1px solid ' + settings.mediumGrey,
       borderRadius: 4,
       boxShadow: '0px 0px 5px 0px rgba(0,0,0,0.2)',
+      overflow: 'hidden',
       width: 370
     };
   }
@@ -118,24 +119,23 @@ export default class FormChrome extends React.Component {
   }
 
   getLoaderStyles(isBackground = false) {
+    const base = {
+      display: this.state.updatingInactiveMessage ? 'block' : 'none',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0
+    };
+
     if (isBackground) {
       return {
-        display: this.state.updatingInactiveMessage ? 'block' : 'none',
-        backgroundColor: 'rgba(0, 0, 0, .2)',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0
+        ...base,
+        backgroundColor: 'rgba(0, 0, 0, .2)'
       };
     } else {
       return {
-        display: this.state.updatingInactiveMessage ? 'block' : 'none',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
+        ...base,
         animation: 'load 2s infinite ease',
         backgroundImage: 'url(/img/apple-icon-120x120.png)',
         backgroundRepeat: 'no-repeat',

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -1,17 +1,22 @@
 import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import _ from 'lodash';
+import {connect} from 'react-redux';
+import {updateInactiveMessage} from 'forms/FormActions';
 import Badge from 'components/Badge';
 import color from 'color';
 import AngleDownIcon from 'react-icons/lib/fa/angle-down';
 import AngleUpIcon from 'react-icons/lib/fa/angle-up';
 import SaveIcon from 'react-icons/lib/fa/floppy-o';
+import onClickOutside from 'react-onclickoutside';
 
 import Button from 'components/Button';
 import RadioButton from 'components/forms/RadioButton';
 
 import settings from 'settings';
 
+@connect()
+@onClickOutside
 @Radium
 export default class FormChrome extends React.Component {
 
@@ -70,6 +75,7 @@ export default class FormChrome extends React.Component {
   getStatusDropdownStyles() {
     return {
       display: this.state.statusDropdownOpen ? 'block' : 'none',
+      zIndex: 2,
       position: 'absolute',
       top: 55,
       right: 5,
@@ -95,6 +101,19 @@ export default class FormChrome extends React.Component {
     return this.state.statusDropdownOpen ? <AngleUpIcon /> : <AngleDownIcon />;
   }
 
+  setInactiveMessage(e) { // onBlur handler for the message textarea
+    console.log('set inactive message', e.target.value);
+  }
+
+  updateInactiveMessage() {
+    console.log('updateInactiveMessage');
+    console.log(this.props.form);
+  }
+
+  handleClickOutside(evt) {
+    this.setState({statusDropdownOpen: false});
+  }
+
   render() {
     let name = _.has(this.props, 'form.header.title') ? this.props.form.header.title :
       this.props.create ? 'Untitled Form' : '';
@@ -104,6 +123,8 @@ export default class FormChrome extends React.Component {
     }
 
     const {form} = this.props;
+
+    console.log('FormChrome', form);
 
     return (
       <div style={styles.base}>
@@ -160,11 +181,13 @@ export default class FormChrome extends React.Component {
                     style={styles.closeRadio}
                     checked={form.status === 'closed'}
                     onClick={this.props.updateStatus} />
-                  <textarea style={styles.statusMessage}></textarea>
+                  <textarea
+                    onBlur={this.setInactiveMessage.bind(this)}
+                    style={styles.statusMessage}></textarea>
                   <Button
                     style={{float: 'left', marginRight: 10}}
                     category="success"
-
+                    onClick={this.updateInactiveMessage.bind(this)}
                     >Save <SaveIcon /></Button>
                   <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>
                 </div>

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -80,6 +80,16 @@ export default class FormChrome extends React.Component {
     };
   }
 
+  getStatusSelectStyle() {
+    return {
+      padding: '12px 12px 0',
+      borderRadius: 5,
+      cursor: 'pointer',
+      userSelect: 'none',
+      backgroundColor: this.state.statusDropdownOpen ? '#d8d8d8' : '#fff'
+    };
+  }
+
   getAngleBtn() {
     return this.state.statusDropdownOpen ? <AngleUpIcon /> : <AngleDownIcon />;
   }
@@ -91,6 +101,8 @@ export default class FormChrome extends React.Component {
     if (name.length > 15) {
       name = name.split(' ').slice(0, 4).join(' ') + '…'; // use ellipsis character
     }
+
+    const {form} = this.props;
 
     return (
       <div style={styles.base}>
@@ -121,25 +133,42 @@ export default class FormChrome extends React.Component {
             </div>
           </div>
 
-          <div style={styles.statusSelect} onClick={this.toggleDropdown.bind(this)}>
-            <span style={{fontWeight: 'bold'}}>Form Status:</span> {this.props.form ? this.props.form.status : ''} {this.getAngleBtn()}
-          </div>
+          {
+            form ?
+              <div style={this.getStatusSelectStyle()} onClick={this.toggleDropdown.bind(this)}>
+                <span style={{fontWeight: 'bold'}}>Form Status:</span> {form.status} {this.getAngleBtn()}
+              </div> :
+              null
+          }
 
-          <div style={this.getStatusDropdownStyles()}>
-            <div style={styles.tabBkd} />
-            <div style={styles.tab} />
-            <RadioButton style={styles.openRadio} label="Open" value="open" onClick={this.props.updateStatus} />
-            <div style={styles.closeRadio}>
-              <RadioButton value="closed" label="Closed" onClick={this.props.updateStatus} />
-              <textarea style={styles.statusMessage}></textarea>
-              <Button
-                style={{float: 'left', marginRight: 10}}
-                category="success"
+          {
+            form ?
+              <div style={this.getStatusDropdownStyles()}>
+                <div style={styles.tabBkd} />
+                <div style={styles.tab} />
+                <RadioButton
+                  style={styles.openRadio}
+                  label="Open"
+                  value="open"
+                  checked={form.status === 'open'}
+                  onClick={this.props.updateStatus} />
+                <div style={styles.closeRadio}>
+                  <RadioButton
+                    value="closed"
+                    label="Closed"
+                    checked={form.status === 'closed'}
+                    onClick={this.props.updateStatus} />
+                  <textarea style={styles.statusMessage}></textarea>
+                  <Button
+                    style={{float: 'left', marginRight: 10}}
+                    category="success"
 
-              >Save <SaveIcon /></Button>
-            <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>
-            </div>
-          </div>
+                    >Save <SaveIcon /></Button>
+                  <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>
+                </div>
+              </div> :
+              null
+          }
 
         </div>
 
@@ -197,11 +226,6 @@ const styles = {
   disabled: {
     display: 'none'
   },
-  statusSelect: {
-    padding: '12px 12px 0',
-    borderRadius: 5,
-    backgroundColor: '#d8d8d8'
-  },
   badge: {
     backgroundColor: color(settings.brandColor).darken(0.1).hexString(),
     fontSize: '14px',
@@ -246,6 +270,7 @@ const styles = {
     border: '1px solid ' + settings.mediumGrey,
     height: 50,
     borderRadius: 4,
+    fontSize: '14px',
     marginBottom: 10
   }
 };

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -76,6 +76,7 @@ export default class FormChrome extends React.Component {
       background: 'white',
       border: '1px solid ' + settings.mediumGrey,
       borderRadius: 4,
+      boxShadow: '0px 0px 5px 0px rgba(0,0,0,0.2)',
       width: 370
     };
   }
@@ -152,10 +153,11 @@ export default class FormChrome extends React.Component {
                   value="open"
                   checked={form.status === 'open'}
                   onClick={this.props.updateStatus} />
-                <div style={styles.closeRadio}>
+                <div style={styles.closeStatusHolder}>
                   <RadioButton
                     value="closed"
                     label="Closed"
+                    style={styles.closeRadio}
                     checked={form.status === 'closed'}
                     onClick={this.props.updateStatus} />
                   <textarea style={styles.statusMessage}></textarea>
@@ -262,8 +264,11 @@ const styles = {
     padding: 20,
     borderBottom: '1px solid ' + settings.mediumGrey
   },
-  closeRadio: {
+  closeStatusHolder: {
     padding: 20
+  },
+  closeRadio: {
+    marginBottom: 15
   },
   statusMessage: {
     width: '100%',

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -1,9 +1,14 @@
 import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import _ from 'lodash';
-import Select from 'react-select';
 import Badge from 'components/Badge';
 import color from 'color';
+import AngleDownIcon from 'react-icons/lib/fa/angle-down';
+import AngleUpIcon from 'react-icons/lib/fa/angle-up';
+import SaveIcon from 'react-icons/lib/fa/floppy-o';
+
+import Button from 'components/Button';
+import RadioButton from 'components/forms/RadioButton';
 
 import settings from 'settings';
 
@@ -15,11 +20,16 @@ export default class FormChrome extends React.Component {
     activeTab: PropTypes.oneOf(['builder', 'submissions', 'gallery']).isRequired,
     form: PropTypes.object,
     gallery: PropTypes.object,
-    updateStatus: PropTypes.func
+    updateStatus: PropTypes.func.isRequired
   }
 
   static contextTypes = {
     router: PropTypes.object.isRequired
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {statusDropdownOpen: false};
   }
 
   buildForm() { // navigate to the form builder or editor
@@ -53,6 +63,27 @@ export default class FormChrome extends React.Component {
     return this.props.submissions ? <Badge style={styles.badge} count={this.props.submissions.length} /> : '';
   }
 
+  toggleDropdown() {
+    this.setState({statusDropdownOpen: !this.state.statusDropdownOpen});
+  }
+
+  getStatusDropdownStyles() {
+    return {
+      display: this.state.statusDropdownOpen ? 'block' : 'none',
+      position: 'absolute',
+      top: 55,
+      right: 5,
+      background: 'white',
+      border: '1px solid ' + settings.mediumGrey,
+      borderRadius: 4,
+      width: 370
+    };
+  }
+
+  getAngleBtn() {
+    return this.state.statusDropdownOpen ? <AngleUpIcon /> : <AngleDownIcon />;
+  }
+
   render() {
     let name = _.has(this.props, 'form.header.title') ? this.props.form.header.title :
       this.props.create ? 'Untitled Form' : '';
@@ -60,11 +91,6 @@ export default class FormChrome extends React.Component {
     if (name.length > 15) {
       name = name.split(' ').slice(0, 4).join(' ') + '…'; // use ellipsis character
     }
-
-    const statusOptions = [
-      {label: 'Open', value: 'open'},
-      {label: 'Closed', value: 'closed'}
-    ];
 
     return (
       <div style={styles.base}>
@@ -95,12 +121,24 @@ export default class FormChrome extends React.Component {
             </div>
           </div>
 
-          <div style={styles.statusSelect}>
-            <Select
-              options={statusOptions}
-              style={styles.statusPicker}
-              value={this.props.form && this.props.form.status}
-              onChange={this.props.updateStatus} />
+          <div style={styles.statusSelect} onClick={this.toggleDropdown.bind(this)}>
+            <span style={{fontWeight: 'bold'}}>Form Status:</span> {this.props.form ? this.props.form.status : ''} {this.getAngleBtn()}
+          </div>
+
+          <div style={this.getStatusDropdownStyles()}>
+            <div style={styles.tabBkd} />
+            <div style={styles.tab} />
+            <RadioButton style={styles.openRadio} label="Open" value="open" onClick={this.props.updateStatus} />
+            <div style={styles.closeRadio}>
+              <RadioButton value="closed" label="Closed" onClick={this.props.updateStatus} />
+              <textarea style={styles.statusMessage}></textarea>
+              <Button
+                style={{float: 'left', marginRight: 10}}
+                category="success"
+
+              >Save <SaveIcon /></Button>
+            <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>
+            </div>
           </div>
 
         </div>
@@ -160,11 +198,54 @@ const styles = {
     display: 'none'
   },
   statusSelect: {
-    width: 110
+    padding: '12px 12px 0',
+    borderRadius: 5,
+    backgroundColor: '#d8d8d8'
   },
   badge: {
     backgroundColor: color(settings.brandColor).darken(0.1).hexString(),
     fontSize: '14px',
     color: 'white'
+  },
+  tab: {
+    display: 'block',
+    content: '',
+    width: 16,
+    height: 16,
+    borderTop: '8px solid transparent',
+    borderLeft: '8px solid transparent',
+    borderRight: '8px solid transparent',
+    borderBottom: '8px solid white',
+    position: 'absolute',
+    top: -16,
+    right: 30
+  },
+  tabBkd: {
+    display: 'block',
+    content: '',
+    width: 18,
+    height: 18,
+    borderTop: '9px solid transparent',
+    borderRight: '9px solid transparent',
+    borderLeft: '9px solid transparent',
+    borderBottom: '9px solid ' + settings.mediumGrey,
+    position: 'absolute',
+    top: -18,
+    right: 29
+  },
+  openRadio: {
+    width: '100%',
+    padding: 20,
+    borderBottom: '1px solid ' + settings.mediumGrey
+  },
+  closeRadio: {
+    padding: 20
+  },
+  statusMessage: {
+    width: '100%',
+    border: '1px solid ' + settings.mediumGrey,
+    height: 50,
+    borderRadius: 4,
+    marginBottom: 10
   }
 };

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -34,7 +34,7 @@ export default class FormChrome extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {statusDropdownOpen: false};
+    this.state = {statusDropdownOpen: false, updatingInactiveMessage: false};
   }
 
   buildForm() { // navigate to the form builder or editor
@@ -102,16 +102,47 @@ export default class FormChrome extends React.Component {
   }
 
   setInactiveMessage(e) { // onBlur handler for the message textarea
-    console.log('set inactive message', e.target.value);
+    this.setState({inactiveMessageDraft: e.target.value});
   }
 
   updateInactiveMessage() {
-    console.log('updateInactiveMessage');
-    console.log(this.props.form);
+    this.setState({updatingInactiveMessage: true})
+    this.props.dispatch(updateInactiveMessage(this.state.inactiveMessageDraft, this.props.form))
+      .then(() => {
+        this.setState({statusDropdownOpen: false, updatingInactiveMessage: false});
+      });
   }
 
   handleClickOutside(evt) {
     this.setState({statusDropdownOpen: false});
+  }
+
+  getLoaderStyles(isBackground = false) {
+    if (isBackground) {
+      return {
+        display: this.state.updatingInactiveMessage ? 'block' : 'none',
+        backgroundColor: 'rgba(0, 0, 0, .2)',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0
+      };
+    } else {
+      return {
+        display: this.state.updatingInactiveMessage ? 'block' : 'none',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        animation: 'load 2s infinite ease',
+        backgroundImage: 'url(/img/apple-icon-120x120.png)',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center center'
+      };
+    }
+
   }
 
   render() {
@@ -123,8 +154,6 @@ export default class FormChrome extends React.Component {
     }
 
     const {form} = this.props;
-
-    console.log('FormChrome', form);
 
     return (
       <div style={styles.base}>
@@ -186,10 +215,12 @@ export default class FormChrome extends React.Component {
                     style={styles.statusMessage}></textarea>
                   <Button
                     style={{float: 'left', marginRight: 10}}
-                    category="success"
+                    category={this.state.updatingInactiveMessage ? 'disabled' : 'success'}
                     onClick={this.updateInactiveMessage.bind(this)}
                     >Save <SaveIcon /></Button>
                   <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>
+                  <div style={this.getLoaderStyles(this, true)} />
+                  <div style={this.getLoaderStyles()} />
                 </div>
               </div> :
               null

--- a/src/components/forms/RadioButton.jsx
+++ b/src/components/forms/RadioButton.jsx
@@ -8,7 +8,9 @@ import settings from '../../settings';
 export default class RadioButton extends React.Component {
 
   static propTypes = {
-    value: PropTypes.any.isRequired
+    label: PropTypes.string,
+    value: PropTypes.any.isRequired,
+    onClick: PropTypes.func.isRequired
   }
 
   getWrapperStyles() {
@@ -39,10 +41,10 @@ export default class RadioButton extends React.Component {
 
   getLabelStyles() {
     return {
-      display: "inline",
+      display: 'inline',
       left: -12,
       marginRight: 4,
-      position: "relative"
+      position: 'relative'
     };
   }
 
@@ -50,8 +52,8 @@ export default class RadioButton extends React.Component {
 
   }
 
-  clickHandler(e) {
-    this.props.handleClick(this.props.order, this.props.value);
+  clickHandler() {
+    this.props.onClick(this.props.value);
   }
 
   getRadioButtonStyles() {
@@ -76,7 +78,7 @@ export default class RadioButton extends React.Component {
       active: {
         backgroundColor: activeColor
       }
-    }
+    };
   }
 
   render() {
@@ -84,7 +86,7 @@ export default class RadioButton extends React.Component {
     const radioButtonStyles = this.getRadioButtonStyles();
 
     return (
-      <div style={this.getWrapperStyles()}>
+      <div style={[this.getWrapperStyles(), this.props.style]}>
         <span
           style={this.getLabelWrapperStyles()}
           onClick={this.clickHandler.bind(this)}

--- a/src/filters/FilterDate.jsx
+++ b/src/filters/FilterDate.jsx
@@ -1,7 +1,8 @@
 import React, {PropTypes} from 'react';
 import {connect} from 'react-redux';
 import Radium from 'radium';
-import DatePicker from 'react-datepicker';
+// https://github.com/Hacker0x01/react-datepicker/issues/483
+import DatePicker from 'react-datepicker/lib/datepicker';
 import moment from 'moment';
 
 @connect()

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -303,9 +303,8 @@ export const saveForm = (form, widgets) => {
 
 };
 
-export const editForm = (form, widgets) => {
+export const editForm = (form) => {
   const data = {...form};
-  data.steps[0].widgets = widgets;
 
   return (dispatch, getState) => {
     const {app} = getState();
@@ -323,9 +322,8 @@ export const editForm = (form, widgets) => {
   };
 };
 
-export const updateInactiveMessage = (message, form, widgets) => {
+export const updateInactiveMessage = (message, form) => {
   const formData = {...form};
-  formData.steps[0].widgets = widgets;
   formData.settings.inactiveMessage = message;
 
   return (dispatch, getState) => {

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -53,6 +53,14 @@ export const ANSWER_EDIT_REQUEST = 'ANSWER_EDIT_REQUEST';
 export const ANSWER_EDIT_SUCCESS = 'ANSWER_EDIT_SUCCESS';
 export const ANSWER_EDIT_FAILED = 'ANSWER_EDIT_FAILED';
 
+export const FORM_EDIT_INIT = 'FORM_EDIT_INIT';
+export const FORM_EDIT_SUCCESS = 'FORM_EDIT_SUCCESS';
+export const FORM_EDIT_FAILURE = 'FORM_EDIT_FAILURE';
+
+export const UPDATE_FORM_INACTIVE_MESSAGE_INIT = 'UPDATE_FORM_INACTIVE_MESSAGE_INIT';
+export const UPDATE_FORM_INACTIVE_MESSAGE_SUCCESS = 'UPDATE_FORM_INACTIVE_MESSAGE_SUCCESS';
+export const UPDATE_FORM_INACTIVE_MESSAGE_FAILURE = 'UPDATE_FORM_INACTIVE_MESSAGE_FAILURE';
+
 const getInit = (body, method) => {
 
   var headers = new Headers({ 'Accept': 'application/json', 'Content-Type': 'application/json' });
@@ -293,6 +301,47 @@ export const saveForm = (form, widgets) => {
     });
   };
 
+};
+
+export const editForm = (form, widgets) => {
+  const data = {...form};
+  data.steps[0].widgets = widgets;
+
+  return (dispatch, getState) => {
+    const {app} = getState();
+
+    dispatch({type: FORM_EDIT_INIT, data});
+    return fetch(`${app.elkhornHost}/create`, getInit(data, 'POST'))
+    .then(res => res.json())
+    .then(json => {
+      dispatch({type: FORM_EDIT_SUCCESS, data: json});
+      return json;
+    })
+    .catch(error => {
+      dispatch({type: FORM_EDIT_FAILURE, error});
+    });
+  };
+};
+
+export const updateInactiveMessage = (message, form, widgets) => {
+  const formData = {...form};
+  formData.steps[0].widgets = widgets;
+  formData.settings.inactiveMessage = message;
+
+  return (dispatch, getState) => {
+    const {app} = getState();
+
+    dispatch({type: UPDATE_FORM_INACTIVE_MESSAGE_INIT});
+    return fetch(`${app.elkhornHost}/create`, getInit(formData, 'POST'))
+    .then(res => res.json())
+    .then(json => {
+      dispatch({type: UPDATE_FORM_INACTIVE_MESSAGE_SUCCESS, data: json});
+      return json;
+    })
+    .catch(error => {
+      dispatch({type: UPDATE_FORM_INACTIVE_MESSAGE_FAILURE, error});
+    });
+  };
 };
 
 export const fetchSubmissions = formId => {

--- a/src/forms/SubmissionDetail.jsx
+++ b/src/forms/SubmissionDetail.jsx
@@ -193,6 +193,7 @@ const styles = {
     padding: 50
   },
   headerContainer: {
+    display: 'inline-block',
     paddingBottom: 8,
     borderBottom: '1px solid ' + settings.mediumGrey,
     position: 'relative'


### PR DESCRIPTION
## What does this PR do?

This updates the status dropdown to be fancier in line with the designs in #389 I still have to figure out how to set up the saving Inactive message thing, but the design can be commented on.

## How do I test this PR?

- `npm install`
- open a form
- click the dropdown to change a status
- status should change when clicking on radio buttons

@coralproject/frontend
