### PR TITLE
Remove answers from gallery

### DIFF
--- a/src/forms/GalleryAnswer.jsx
+++ b/src/forms/GalleryAnswer.jsx
@@ -55,7 +55,10 @@ export default class GalleryAnswer extends React.Component {
         </div>
         <div style={styles.rightColumn}>
           <div style={styles.modButtons}>
-            <div style={styles.iconHolder} key="foo">
+            <div
+              onClick={this.removeSubmission.bind(this)}
+              style={styles.iconHolder}
+              key="foo">
               <Trash style={styles.icon} />
             </div>
             <div style={styles.iconHolder} key="bar">


### PR DESCRIPTION
## What does this PR do?

There was a regression bug in the design update PR where you could no longer remove an Answer from a gallery. This PR fixes it.

## How do I test this PR?

- go to a gallery
- click the Trash icon
- Answer should disappear from the gallery

@coralproject/frontend

