### PR TITLE
Paginated submissions list

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,5 +32,6 @@
   "Submission Gallery": "Submission Gallery",
   "Create a Search": "Create a Search",
   "Create Search": "Create Search",
+  "Submissions": "Submissions",
   "Create Form": "Create Form"
 }

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -28,6 +28,8 @@ export default class SubmissionList extends Component {
     props.dispatch(fetchForm(props.params.id));
     props.dispatch(fetchGallery(props.params.id));
     props.dispatch(fetchSubmissions(props.params.id));
+
+    this.state = {subPageOffset: 0};
   }
 
   sendToGallery(galleryId, subId, key) {
@@ -110,6 +112,10 @@ class Sidebar extends Component {
     });
   }
 
+  paginate(requestedPage) {
+    console.log('offset', this.state.subPageOffset);
+  }
+
   render() {
     const { submissions, activeSubmission, onSelect} = this.props;
     return (
@@ -130,6 +136,25 @@ class Sidebar extends Component {
           </div>*/}
         </div>
         <div>{this.listSubmissions(submissions, activeSubmission, onSelect)}</div>
+        <div style={styles.sidebar.pagination}>
+          <div
+            onClick={this.paginate.bind(this, 0)}
+            key="alpha"
+            style={styles.sidebar.arrow}>«</div>
+          <div
+            onClick={this.paginate.bind(this, this.state.subPageOffset - 1)}
+            key="bravo"
+            style={styles.sidebar.arrow}>‹</div>
+          <div key="charlie">Page</div>
+          <div
+            onClick={this.paginate.bind(this, this.state.subPageOffset + 1)}
+            key="delta"
+            style={styles.sidebar.arrow}>›</div>
+          <div
+            onClick={this.paginate.bind(this, this.state.subsCount % 10)}
+            key="echo"
+            style={styles.sidebar.arrow}>»</div>
+        </div>
       </div>
     );
   }
@@ -148,6 +173,26 @@ const styles = {
       minWidth: 300,
       marginBottom: 10,
       boxShadow: '0px 0px 5px 0px rgba(0,0,0,0.2)'
+    },
+    pagination: {
+      display: 'flex',
+      justifyContent: 'space-between'
+    },
+    arrow: {
+      width: 32,
+      height: 32,
+      textAlign: 'center',
+      cursor: 'pointer',
+      color: settings.grey,
+      fontSize: '20px',
+      fontWeight: 'bold',
+      backgroundColor: 'transparent',
+      borderRadius: 16,
+      lineHeight: '1.5em',
+      ':hover': {
+        color: '#000',
+        backgroundColor: settings.grey
+      }
     },
     icon: {
       marginLeft: 3

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -59,7 +59,7 @@ export default class SubmissionList extends Component {
     const gallery = this.props.forms[activeGallery];
 
     return (
-      <Page>
+      <Page style={styles.page}>
         <div style={styles.container}>
           <FormChrome
             activeTab="submissions"
@@ -69,7 +69,6 @@ export default class SubmissionList extends Component {
             form={form}/>
           <Sidebar
             form={form}
-            dispatch={this.props.dispatch}
             submissions={submissions.reverse()}
             activeSubmission={activeSubmission}
             onSelect={this.onSubmissionSelect.bind(this)} />
@@ -90,6 +89,7 @@ export default class SubmissionList extends Component {
   }
 }
 
+@connect()
 @Radium
 class Sidebar extends Component {
 
@@ -154,7 +154,7 @@ class Sidebar extends Component {
     const { submissions, activeSubmission, onSelect, form} = this.props;
 
     return (
-      <div>
+      <div style={styles.sidebar}>
         <div style={styles.sidebar.container}>
           <div style={styles.sidebar.countContainer}>
             <p style={styles.sidebar.count}>{submissions.length} Submission{submissions.length === 1 ? '' : 's'}</p>
@@ -202,10 +202,21 @@ class Sidebar extends Component {
 }
 
 const styles = {
+  page: {
+    position: 'absolute',
+    top: 50,
+    bottom: 0,
+    left: 0,
+    right: 0
+  },
   container: {
-    display: 'flex'
+    display: 'flex',
+    height: '100%'
   },
   sidebar: {
+    height: '100%',
+    position: 'relative',
+
     container: {
       flex: 1,
       display: 'flex',
@@ -216,6 +227,10 @@ const styles = {
       boxShadow: '0px 0px 5px 0px rgba(0,0,0,0.2)'
     },
     pagination: {
+      position: 'absolute',
+      width: '100%',
+      bottom: 0,
+      backgroundColor: settings.bgColorBase,
       display: 'flex',
       justifyContent: 'space-between'
     },

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -65,7 +65,7 @@ export default class FormChrome extends React.Component {
   }
 
   submissionBadge() {
-    return this.props.submissions ? <Badge style={styles.badge} count={this.props.submissions.length} /> : '';
+    return this.props.form ? <Badge style={styles.badge} count={this.props.form.stats.responses} /> : '';
   }
 
   toggleDropdown() {

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -350,10 +350,11 @@ export const updateInactiveMessage = (message, form) => {
   };
 };
 
-export const fetchSubmissions = formId => {
+export const fetchSubmissions = (formId, page = 0) => {
   return (dispatch, getState) => {
     const {app} = getState();
-    fetch(`${app.pillarHost}/api/form_submissions/${formId}`)
+    const skip = page * 10;
+    fetch(`${app.pillarHost}/api/form_submissions/${formId}?skip=${skip}&limit=10`)
       .then(res => res.json())
       .then(submissions => dispatch(submissionsFetched(submissions)))
       .catch(error => dispatch(submissionsFetchError(error)));

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -354,7 +354,7 @@ export const fetchSubmissions = (formId, page = 0) => {
   return (dispatch, getState) => {
     const {app} = getState();
     const skip = page * 10;
-    fetch(`${app.pillarHost}/api/form_submissions/${formId}?skip=${skip}&limit=10`)
+    return fetch(`${app.pillarHost}/api/form_submissions/${formId}?skip=${skip}&limit=10`)
       .then(res => res.json())
       .then(submissions => dispatch(submissionsFetched(submissions)))
       .catch(error => dispatch(submissionsFetchError(error)));


### PR DESCRIPTION
## What does this PR do?

Adds the ability to paginate 10 at a time through the submission list manager.

## How do I test this PR?

- view a form with more than 10 submissions (preferably more than 20) e.g. `http://localhost:3000/forms/57629fd93bc37e00055456c1/submissions`
- click the buttons at the bottom of the list
- the pages should navigate through 10 submissions at a time
- the `«` and `»` should go to the first and last pages, respectively

fixes #299 

@coralproject/frontend
