### PR TITLE
Form Builder: bug when duplicating a field

### DIFF
--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -102,7 +102,7 @@ export default class FormBuilder extends Component {
       identity: data.identity ? data.identity : false,
       wrapper: {},
       props: { ...data.props },
-      id: Math.floor(Math.random() * 99999) + ''
+      id: uuid.v4() + ''
     }));
   }
 

--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -102,7 +102,7 @@ export default class FormBuilder extends Component {
       identity: data.identity ? data.identity : false,
       wrapper: {},
       props: { ...data.props },
-      id: uuid.v4() + ''
+      id: uuid.v4()
     }));
   }
 

--- a/src/forms/FormsReducer.js
+++ b/src/forms/FormsReducer.js
@@ -110,6 +110,7 @@ const forms = (state = initial, action) => {
 
     var widgetsCopy = state.widgets.slice();
     var widgetCopy = Object.assign({}, widgetsCopy[position]);
+    widgetCopy.id = uuid.v4();
 
     var fieldsBefore = widgetsCopy.slice(0, position);
     var fieldsAfter = widgetsCopy.slice(position);


### PR DESCRIPTION
## What does this PR do?
- Fixes a bug when duplicating a field. When editing a duplicated field name, the name of the original name changes too.

## How do I test this PR?
- Go to *Create form*
- Add a field (e.g. Short Answer)
- Edit the field's name
- Duplicate the field
- Edit the newly created field (the duplicate) and edit it's name
- Only the new field should change, not both.
