### PR TITLE
Minor cosmetic change on the preview spinner

### DIFF
--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -136,8 +136,8 @@ export default class FormBuilder extends Component {
     document.getElementsByTagName('head')[0].appendChild(script);
 
     return (
-      <div>
-        <Spinner />
+      <div style={ styles.previewContainer }>
+        <div style={ styles.previewSpinner }><Spinner /></div>
         <div id="ask-form"></div>
       </div>
     );
@@ -315,5 +315,17 @@ const styles = {
   embedCode: {
     width: '100%',
     height: 50
+  },
+  previewContainer: {
+    position: 'relative'
+  },
+  previewSpinner: {
+    position: 'absolute',
+    textAlign: 'center',
+    top: '100px',
+    fontSize: '30pt',
+    width: '200px',
+    left: '50%',
+    marginLeft: '-100px' // width / 2
   }
 };


### PR DESCRIPTION
## What does this PR do?
- Fixes the tiny spinner on the corner of the preview.

## How do I test this PR?
- Go to *Create form*
- Add some fields
- Click preview (eye icon)
- A centered spinner should show for less than a second then be replaced by the preview content. (In master, the spinner remains visible in the top corner).


