### PR TITLE
Using the submissions fields on response

### DIFF
--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -356,7 +356,7 @@ export const fetchSubmissions = (formId, page = 0) => {
     const skip = page * 10;
     return fetch(`${app.pillarHost}/api/form_submissions/${formId}?skip=${skip}&limit=10`)
       .then(res => res.json())
-      .then(submissions => dispatch(submissionsFetched(submissions)))
+      .then(data => dispatch(submissionsFetched(data.submissions)))
       .catch(error => dispatch(submissionsFetchError(error)));
   };
 };


### PR DESCRIPTION
* DO NOT MERGE THIS PR UNTIL THE SUBMISSIONS LIST IS BROKEN FOR YOU :P *

## What does this PR do?

The submission list endpoint will now return an object with counts and submissions. We should do this change when staging is done with the deployiment. 

## How do I test this PR?

- Go to the submission list.
- Inspect the submission list. It should return an object with a submissions property and the list should be still working

@coralproject/frontend

