### PR TITLE
clear filters from previous Saved Search

### DIFF
--- a/src/app/SearchEditor.jsx
+++ b/src/app/SearchEditor.jsx
@@ -11,7 +11,7 @@ import {
   updateEditableSearchMeta
 } from 'search/SearchActions';
 import {userSelected} from 'users/UsersActions';
-import {filterChanged, getFilterRanges} from 'filters/FiltersActions';
+import {clearEditableFilters, filterChanged, getFilterRanges} from 'filters/FiltersActions';
 import {fetchCommentsByUser} from 'comments/CommentsActions';
 
 import Button from 'components/Button';
@@ -50,6 +50,7 @@ export default class SearchEditor extends React.Component {
 */
     dispatch(clearUserList());
     dispatch(userSelected(null));
+    dispatch(clearEditableFilters()); // clear filters out from previous viewing of Saved Search
     dispatch(getFilterRanges(true)); // editMode => true
     dispatch(fetchSavedSearchForEdit(params.id))
     .then(() => dispatch(fetchInitialData(true))); // dispatch after getting search

--- a/src/filters/FiltersActions.js
+++ b/src/filters/FiltersActions.js
@@ -28,6 +28,8 @@ export const SET_SPECIFIC_BREAKDOWN_EDIT = 'SET_SPECIFIC_BREAKDOWN_EDIT';
 export const RESET_FILTERS = 'RESET_FILTERS';
 export const RESET_FILTER = 'RESET_FILTER';
 
+export const CLEAR_EDITABLE_FILTERS = 'CLEAR_EDITABLE_FILTERS';
+
 export const SORT = 'SORT';
 
 // export const REQUEST_FILTER_RANGES = 'REQUEST_FILTER_RANGES';
@@ -373,4 +375,34 @@ const resetFilterAction = (name) => {
 
     dispatch({type: RESET_FILTER, filter: {[name]: resetFilter}});
   };
+};
+
+export const clearEditableFilters = () => {
+
+  return (dispatch, getState) => {
+    const {filters} = getState();
+    // loop over the editable filters and re-initialize them.
+    // ranges are being loaded from the server while this is happening.
+    const defaults = filters.editFilterList.reduce((accum, key) => {
+
+      let filter = filters[key];
+      const min = _.isUndefined(filter.minRange) ? null : filter.minRange;
+      const max = _.isUndefined(filter.maxRange) ? null : filter.maxRange;
+      const userMin = _.isNull(min) ? null : filter.minRange;
+      const userMax = _.isNull(max) ? null : filter.maxRange;
+
+      filter = {...filter, min, max, userMin, userMax};
+
+      if (filter.type === 'intDateProximity') {
+        filter = {...filter, min: 0, userMin: 0, max: 10000, userMax: 10000};
+      }
+
+      accum[key] = filter;
+
+      return accum;
+    }, {});
+
+    dispatch({type: CLEAR_EDITABLE_FILTERS, filters: defaults});
+  };
+
 };

--- a/src/filters/FiltersReducer.js
+++ b/src/filters/FiltersReducer.js
@@ -140,6 +140,11 @@ const filters = (state = initialState, action) => {
   case types.SORT:
     const sortBy = action.template ? [action.template, action.direction] : null;
     return {...state, sortBy};
+
+  case types.CLEAR_EDITABLE_FILTERS:
+    // reset editable filters to their default state while a Saved Search is loading
+    return {...state, ...action.filters};
+
   default:
     return state;
   }

--- a/src/filters/FiltersReducer.js
+++ b/src/filters/FiltersReducer.js
@@ -143,7 +143,7 @@ const filters = (state = initialState, action) => {
 
   case types.CLEAR_EDITABLE_FILTERS:
     // reset editable filters to their default state while a Saved Search is loading
-    return {...state, ...action.filters};
+    return {...state, ...action.filters, breakdownEdit: 'all', specificBreakdownEdit: ''};
 
   default:
     return state;


### PR DESCRIPTION
## What does this PR do?

fixes #493 

## How do I test this PR?

- go through the steps on #493 
- when you're redirected to the Edit Search page upon saving the new search, only the filters in your newly minted Search should be there.

@coralproject/frontend

