### PR TITLE
remove dependency on saved xenia query

### DIFF
--- a/src/comments/CommentsActions.js
+++ b/src/comments/CommentsActions.js
@@ -30,12 +30,23 @@ export const receiveCommentsFailure = (err) => {
 
 /* xenia_package */
 export const fetchCommentsByUser = (user_id) => {
-
+  // we should figure out how to paginate this at some point.
   return (dispatch) => {
     dispatch(clearCommentItems());
     dispatch(requestComments());
 
-    xenia().exec('comments_by_user', {user_id})
+    xenia({
+      name: 'comments_by_userid',
+      desc: 'get a reverse chron list of comments'
+    }).addQuery().collection('comments')
+      .match({user_id: `#objid:${user_id}`})
+      .sort(['date_created', -1])
+      .skip(0)
+      .limit(50)
+      // there's a bunch of good stuff here.
+      // we need to do another pass to make the comment list more interesting
+      .include(['body', 'date_created', 'date_updated'])
+      .exec()
       .then(data => {
         dispatch(receiveComments(data));
         dispatch(storeComments(data));


### PR DESCRIPTION
## What does this PR do?

This removes the dependency on a xenia saved query_set to show comments per user, and updates the code to use @impronunciable's sweet xeniadriver-js library. The end result is clearer logic.

fixes #490 

## How do I test this PR?

- run any search
- select a user
- see that all their comments are in reverse chronological order

@coralproject/frontend

