### PR TITLE
attempt at simple fix for js float weirdness

### DIFF
--- a/src/filters/FilterNumberPercent.jsx
+++ b/src/filters/FilterNumberPercent.jsx
@@ -58,16 +58,26 @@ export default class FilterNumbers extends React.Component {
         <p style={styles.description}>{this.props.description}</p>
         <div>
           <input
-            onChange={event => this.props.onChange(this.props.fieldName, 'userMin', event.target.value/100)}
+            onChange={event => {
+              let val = parseFloat(event.target.value, 10) / 100;
+              // just in case something crazy is happening
+              val = Math.abs(val) < 0.001 ? 0 : val;
+              this.props.onChange(this.props.fieldName, 'userMin', val);
+            }}
             style={styles.minMaxInputs}
             type='number'
-            value={Math.floor(this.props.userMin*100)}/>
+            value={Math.floor(this.props.userMin * 100)}/>
           {` - `}
           <input
-            onChange={event => this.props.onChange(this.props.fieldName, 'userMax', event.target.value/100)}
+            onChange={event => {
+              let val = parseFloat(event.target.value, 10) / 100;
+              // just in case something crazy is happening
+              val = Math.abs(val) < 0.001 ? 0 : val;
+              this.props.onChange(this.props.fieldName, 'userMax', val);
+            }}
             style={styles.minMaxInputs}
             type='number'
-            value={Math.floor(this.props.userMax*100)}/>
+            value={Math.floor(this.props.userMax * 100)}/>
           <p style={{marginTop: 10, color: 'red'}}>{this.renderHelpText()}</p>
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

Before we were dividing strings by numbers in the percentage filter, and who knows what mayhem this would cause. JS has a long, sad history of dealing with floats. I took a first shot at fixing some input errors that @jde was getting in #498 

## How do I test this PR?

- I couldn't reproduce the behavior
- I guess play around with it and make sure that when you enter `0` in a field, that the query going to xenia does in fact match `$lte: 0` and not `$lte: 0.003545757` or something crazy

@coralproject/frontend

