### PR TITLE
Adding flash messages feature for errors and warnings

### DIFF
--- a/src/app/MainReducer.js
+++ b/src/app/MainReducer.js
@@ -8,6 +8,7 @@ import tags from 'tags/TagReducer';
 import filters from 'filters/FiltersReducer';
 import users from 'users/UsersReducer';
 import forms from 'forms/FormsReducer';
+import flashMessages from 'flashmessages/FlashMessagesReducer';
 
 const rootReducer = combineReducers({
   app,
@@ -18,7 +19,8 @@ const rootReducer = combineReducers({
   tags,
   filters,
   users,
-  forms
+  forms,
+  flashMessages
 });
 
 export default rootReducer;

--- a/src/app/layout/Page.jsx
+++ b/src/app/layout/Page.jsx
@@ -9,6 +9,7 @@ import Radium from 'radium';
 import Sidebar from 'app/layout/sidebar/Sidebar';
 
 import Header from 'app/layout/header/Header';
+import FlashMessages from 'flashmessages/FlashMessages';
 
 import settings from 'settings';
 
@@ -19,6 +20,7 @@ class Page extends React.Component {
     return (
       <Sidebar styles={styles.sidebar}>
         <Header />
+        <FlashMessages />
         <div style={[styles.wrapper, this.props.style]}>
           {this.props.children}
         </div>

--- a/src/flashmessages/FlashMessages.jsx
+++ b/src/flashmessages/FlashMessages.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Radium from 'radium';
+import { connect } from 'react-redux';
+
+import FaClose from 'react-icons/lib/fa/close';
+import FaCheckCircle from 'react-icons/lib/fa/check-circle';
+
+import { showFlashMessage, hideFlashMessage } from 'flashmessages/FlashMessagesActions';
+
+@connect(({ flashMessages }) => ({ flashMessages }))
+class FlashMessages extends React.Component {
+
+  onCloseClick() {
+    this.props.dispatch(hideFlashMessage());
+  }
+
+  getStyles() {
+    return Object.assign({},
+      styles.base,
+      styles[this.props.flashMessages.type]
+    );
+  }
+
+  render() {
+    let { show, message, type } = this.props.flashMessages;
+    return (
+      show
+      ? <div style={ this.getStyles() }>
+        <span style={ styles.message }>
+          {
+            type == 'success'
+            ? <span style={ styles.check }><FaCheckCircle /></span>
+            : null
+          }
+          { message }
+        </span>
+        <span onClick={ this.onCloseClick.bind(this) } style={ styles.closeButton }>
+          <FaClose />
+        </span>
+      </div>
+      : null
+    );
+  }
+}
+
+export default FlashMessages;
+
+const styles = {
+  base: {
+    position: 'absolute',
+    background: '#EEE',
+    height: '50px',
+    top: '50px',
+    zIndex: '100',
+    width: '100%'
+  },
+  warning: {
+    backgroundColor: '#FEDF98',
+    color: 'black'
+  },
+  success: {
+    backgroundColor: '#4CA57C',
+    color: 'white'
+  },
+  message: {
+    lineHeight: '50px',
+    fontWeight: 'bold',
+    paddingLeft: '20px'
+  },
+  closeButton: {
+    position: 'absolute',
+    height: '50px',
+    width: '50px',
+    lineHeight: '45px',
+    textAlign: 'center',
+    right: '5px',
+    cursor: 'pointer'
+  },
+  check: {
+    marginRight: '10px'
+  }
+};

--- a/src/flashmessages/FlashMessagesActions.js
+++ b/src/flashmessages/FlashMessagesActions.js
@@ -1,0 +1,17 @@
+// Exported constants
+export const SHOW_FLASH_MESSAGE = 'SHOW_FLASH_MESSAGE';
+export const HIDE_FLASH_MESSAGE = 'HIDE_FLASH_MESSAGE';
+
+export const showFlashMessage = (message, messageType) => {
+  return {
+    type: SHOW_FLASH_MESSAGE,
+    message,
+    messageType
+  };
+};
+
+export const hideFlashMessage = () => {
+  return {
+    type: HIDE_FLASH_MESSAGE
+  };
+};

--- a/src/flashmessages/FlashMessagesReducer.js
+++ b/src/flashmessages/FlashMessagesReducer.js
@@ -1,0 +1,27 @@
+import * as flashMessagesActions from 'flashmessages/FlashMessagesActions';
+
+const types = Object.assign({}, flashMessagesActions);
+
+const initialState = {
+  type: 'warning',
+  show: false,
+  message: ''
+};
+
+const flashMessages = (state = initialState, action) => {
+
+  switch (action.type) {
+
+  case types.SHOW_FLASH_MESSAGE:
+    return Object.assign({}, state, { show: true, message: action.message, type: action.messageType });
+
+  case types.HIDE_FLASH_MESSAGE:
+    return Object.assign({}, state, { show: false, message: '', type: 'warning' });
+
+  default:
+    // console.log('no reducer matches:', action.type);
+    return state;
+  }
+};
+
+export default flashMessages;

--- a/src/flashmessages/FlashMessagesReducer.js
+++ b/src/flashmessages/FlashMessagesReducer.js
@@ -1,6 +1,6 @@
-import * as flashMessagesActions from 'flashmessages/FlashMessagesActions';
+import * as FlashMessagesActions from 'flashmessages/FlashMessagesActions';
 
-const types = Object.assign({}, flashMessagesActions);
+const types = Object.assign({}, FlashMessagesActions);
 
 const initialState = {
   type: 'warning',

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -326,6 +326,7 @@ export const saveForm = (form, widgets) => {
     .catch(error => {
       dispatch(formCreationFailure(error));
     });
+
   };
 
 };

--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -1,18 +1,20 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import uuid from 'node-uuid';
-import { saveForm } from 'forms/FormActions';
 
-import Spinner from 'components/Spinner';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
+
+// Actions
+import { saveForm, appendWidget, updateForm } from 'forms/FormActions';
+import { showFlashMessage } from 'flashMessages/FlashMessagesActions';
+
+import Spinner from 'components/Spinner';
 import FaClose from 'react-icons/lib/fa/close';
 
-import { updateForm } from 'forms/FormActions';
 import FormDiagram from 'forms/FormDiagram';
 import { Header, Sidebar } from 'forms/FormBuilderLayout';
 
-import { appendWidget } from 'forms/FormActions';
 
 @connect(({ app, forms }) => ({ app, forms }))
 @DragDropContext(HTML5Backend)
@@ -65,7 +67,14 @@ export default class FormBuilder extends Component {
     const { forms, dispatch, activeForm } = this.props;
     const { form, widgets } = forms;
     dispatch(saveForm(activeForm ? forms[activeForm] : form, widgets))
-      .then(data => !activeForm && router.push(`/forms/${data.id}`));
+      .then(data => {
+        if (data && data.id) {
+          this.props.dispatch(showFlashMessage('Your form saved.', 'success'));
+          return !activeForm && router.push(`/forms/${data.id}`);
+        } else {
+          this.props.dispatch(showFlashMessage('Uh-oh, we can\'t save your form. Try again or report the error to your technical team', 'warning'));
+        }
+      });
   }
 
   onFormStatusChange(e) {

--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -7,7 +7,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 
 // Actions
 import { saveForm, appendWidget, updateForm } from 'forms/FormActions';
-import { showFlashMessage } from 'flashMessages/FlashMessagesActions';
+import { showFlashMessage } from 'flashmessages/FlashMessagesActions';
 
 import Spinner from 'components/Spinner';
 import FaClose from 'react-icons/lib/fa/close';


### PR DESCRIPTION
## What does this PR do?
- Adds a flash messaging feature to cay to show warnings and errors (see: #442 look for Emma's screenshots)

## How do I test this PR?
- Go to **Create form**
- **Stop** Elkhorn.
- Click save -> You'll see a yellow warning.
- **Start** Elkhorn.
- Click save -> You'll see a green success message.

@coralproject/frontend

