### PR TITLE
style gallery preview with css and className

### DIFF
--- a/css/ask-gallery-preview.css
+++ b/css/ask-gallery-preview.css
@@ -1,0 +1,53 @@
+.askGallery {
+  position: relative;
+}
+
+.askGallery__title {
+  font-weight: bold;
+  color: #444;
+  font-size: 24;
+  margin: 20px 20px 10px;
+}
+
+.askGallery__description {
+  color: #444;
+  line-height: 1.3em;
+  font-size: 18px;
+  margin: 10px 20px;
+}
+
+.askGallery__answers {
+  padding: 20px;
+}
+
+.askGallery__answer {
+  background-color: white;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #ddd;
+  margin-bottom: 10px;
+}
+
+.askGallery__pii {
+  color: #979B9F;
+  font-style: italic;
+}
+
+.askgallery__pii-above {
+  margin-bottom: 10px;
+}
+
+.askGallery__pii-below {
+  margin-top: 10px;
+}
+
+.askGallery__answerText {
+  line-height: 1.3em;
+}
+
+.askGallery__answerMultiOption {
+  background-color: #444;
+  font-size: 16px;
+  padding: 8px;
+  color: white;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ window.L.setLocale(window.L.locale);
 
 require('reset.css');
 require('global.css');
+require('ask-gallery-preview.css');
 
 require('react-select.css');
 require('react-datepicker.min.css');


### PR DESCRIPTION
## What does this PR do?

We want the published Gallery to be unstyled so publishers can brand it themselves. In order to do this, I removed the inlined styles that Elkhorn was sending and added some hooks so that the Gallery could be styled with regular css classes.

## How do I test this PR?

- checkout the elkhorn PR/branch https://github.com/coralproject/elkhorn/pull/64
- preview a Gallery.
- everything should look exactly the same in Cay
- if the Gallery is embedded somewhere, it should be completely default.

@coralproject/frontend

