### PR TITLE
render Dates into Submission/Gallery Manager

### DIFF
--- a/src/forms/GalleryAnswer.jsx
+++ b/src/forms/GalleryAnswer.jsx
@@ -31,7 +31,7 @@ export default class GalleryAnswer extends React.Component {
     const selectedIndexes = answer.answer.answer.options.map(o => o.index);
     const options = answer.answer.props.options.map((option, key) => {
       const selected = selectedIndexes.indexOf(key) !== -1;
-      return <li style={[styles.multiple.option, selected && styles.multiple.selected]} key={key}>{key}. {option.title}</li>;
+      return <li style={[styles.multiple.option, selected && styles.multiple.selected]} key={key}>{key + 1}. {option.title}</li>;
     });
 
     // check for Other answer
@@ -57,8 +57,15 @@ export default class GalleryAnswer extends React.Component {
       multipleChoice = this.renderMultipleChoice(answer);
     }
 
-    const text = answer.answer.edited ? answer.answer.edited : answer.answer.answer.text;
+    let unedited = answer.answer.answer.value ? answer.answer.answer.value : answer.answer.answer.text;
+    let text = answer.answer.edited ? answer.answer.edited : unedited;
     const statusFlag = answer.answer.edited ? 'edited' : 'new';
+
+    // render as a formatted Date if possible
+    const possibleDateValue = new Date(text);
+    if (_.isString(answer.answer.answer.value) && _.isDate(possibleDateValue) && !isNaN(possibleDateValue)) {
+      text = moment(possibleDateValue).format('D MMM YYYY');
+    }
 
     if (!gallery) {
       return <p>Loading gallery...</p>;

--- a/src/forms/SubmissionDetail.jsx
+++ b/src/forms/SubmissionDetail.jsx
@@ -5,6 +5,7 @@ import BBookmark from 'react-icons/lib/fa/bookmark';
 import PaperPlaneIcon from 'react-icons/lib/fa/paper-plane';
 import FlagIcon from 'react-icons/lib/fa/flag';
 import TrashIcon from 'react-icons/lib/fa/trash';
+import _ from 'lodash';
 
 import settings from 'settings';
 import Button from 'components/Button';
@@ -89,6 +90,14 @@ export default class SubmissionDetail extends Component {
       return (<span>No response</span>);
     }
 
+    // wow, this is a gross hack, and it WILL break soon
+    const possibleDateValue = new Date(reply.answer.value);
+
+    // render a Date answer
+    if (_.isString(reply.answer.value) && _.isDate(possibleDateValue) && !isNaN(possibleDateValue)) {
+      return moment(possibleDateValue).format('D MMM YYYY');
+    }
+
     if (reply.answer.options) {
 
       const selectedIndexes = reply.answer.options.map(o => o.index);
@@ -104,6 +113,11 @@ export default class SubmissionDetail extends Component {
           })}
         </ul>
       );
+    }
+
+    // if the date was invalid, just show whatever they entered.
+    if ('value' in reply.answer) {
+      return reply.answer.value;
     }
 
     if ('text' in reply.answer) {

--- a/src/forms/SubmissionListSidebar.js
+++ b/src/forms/SubmissionListSidebar.js
@@ -217,7 +217,10 @@ const styles = {
     width: 35,
     height: 35,
     backgroundColor: '#fff',
-    border: '1px solid #ccc',
+    borderTop: '1px solid #ccc',
+    borderRight: '1px solid #ccc',
+    borderBottom: '1px solid #ccc',
+    borderLeft: '1px solid #ccc',
     display: 'inline-block',
     color: 'rgb(94,94,94)',
     cursor: 'pointer'
@@ -237,7 +240,9 @@ const styles = {
   },
   searchContainer: {
     display: 'flex',
-    margin: 10,
+    marginRight: 10,
+    marginBottom: 10,
+    marginLeft: 10,
     marginTop: 0
   }
 };


### PR DESCRIPTION
## What does this PR do?

fixes https://github.com/coralproject/ask/issues/25

## How do I test this PR?

- select a gallery with some Date responses in it like {{cayHost}}/579672167bb36b00072d9c49/gallery
- see that the Dates are rendered now instead of being blank

@coralproject/frontend

