### PR TITLE
Form field description not being added by default to the fields

### DIFF
--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -81,6 +81,7 @@ export default class FormBuilder extends Component {
     this.markAsUnsaved();
     this.props.dispatch(appendWidget({
       title: data.title,
+      description: data.description,
       friendlyType: data.friendlyType,
       type: 'field',
       component: data.type,

--- a/src/forms/FormComponent.js
+++ b/src/forms/FormComponent.js
@@ -203,7 +203,7 @@ export default class FormComponent extends Component {
                 <input
                   onChange={ this.onTitleChange.bind(this) }
                   style={ styles.fieldTitle }
-                  defaultValue={ this.props.field.title }
+                  defaultValue={ field.title }
                   type="text"
                   placeholder={ `Ask readers a question (${ field.friendlyType })` } />
                 <input

--- a/src/forms/FormDiagram.js
+++ b/src/forms/FormDiagram.js
@@ -150,6 +150,7 @@ export default class FormDiagram extends Component {
     this.props.markAsUnsaved();
     this.props.dispatch(appendWidget({
       title: field.title,
+      description: field.description,
       type: 'field',
       component: field.type,
       identity: false,


### PR DESCRIPTION
## What does this PR do?
- Partially fixes: https://github.com/coralproject/ask/issues/29

## What is missing?
- Looks like the description data is being sent to Pillar:
<img width="454" alt="captura de pantalla 2016-07-25 a las 21 56 46" src="https://cloud.githubusercontent.com/assets/340766/17122739/67d53530-52b4-11e6-8a76-bd9b34c118ce.png">

- But it's not being saved. Don't know exactly why, according to this: https://github.com/coralproject/pillar/blob/97722b8bae7d830c37c47d2f9d7b903ac02a2797/pkg/model/form.go#L10

...looks like there is no `description` in the `FormWidget` struct.
 
@coralproject/frontend

