### PR TITLE
pagination reflects search result total.

### DIFF
--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -102,7 +102,6 @@ export default class SubmissionList extends Component {
             onSelect={this.onSubmissionSelect.bind(this)} />
           <SubmissionDetail
             submission={submission}
-            submissionId={submissionList.length - submissionList.indexOf(activeSubmission)}
             removeFromGallery={this.removeFromGallery.bind(this)}
             sendToGallery={this.sendToGallery.bind(this)}
             gallery={gallery}

--- a/src/components/lists/Pagination.js
+++ b/src/components/lists/Pagination.js
@@ -1,40 +1,51 @@
 
 import React from 'react';
+import Radium from 'radium';
 import { bgColorBase, grey } from 'settings';
 
-export default ({ current, total, onChange }) => (
-  <div style={styles.pagination}>
-    <div
-      onClick={() => onChange(0)}
-      key="alpha"
-      style={styles.arrow}>«</div>
-    <div
-      onClick={() => current && onChange(current - 1)}
-      key="bravo"
-      style={styles.arrow}>‹</div>
-    <div
-      style={styles.pageNum}
-      key="charlie">Page {current + 1} of {total}</div>
-    <div
-      onClick={() => current < total && onChange(current + 1)}
-      key="delta"
-      style={styles.arrow}>›</div>
-    <div
-      onClick={() => onChange(total - 1)}
-      key="echo"
-      style={styles.arrow}>»</div>
-  </div>
-);
+@Radium
+export default class Pagination extends React.Component {
+
+  render() {
+
+    const { current, total, onChange } = this.props;
+
+    const paginationStyle = {
+      position: 'absolute',
+      width: '100%',
+      bottom: -30,
+      backgroundColor: bgColorBase,
+      display: total > 1 ? 'flex' : 'none',
+      justifyContent: 'space-between'
+    };
+
+    return (
+      <div style={paginationStyle}>
+        <div
+          onClick={() => onChange(0)}
+          key="alpha"
+          style={styles.arrow}>«</div>
+        <div
+          onClick={() => current && onChange(current - 1)}
+          key="bravo"
+          style={styles.arrow}>‹</div>
+        <div
+          style={styles.pageNum}
+          key="charlie">Page {current + 1} of {total}</div>
+        <div
+          onClick={() => current < total && onChange(current + 1)}
+          key="delta"
+          style={styles.arrow}>›</div>
+        <div
+          onClick={() => onChange(total - 1)}
+          key="echo"
+          style={styles.arrow}>»</div>
+      </div>
+    );
+  }
+}
 
 const styles = {
-  pagination: {
-    position: 'absolute',
-    width: '100%',
-    bottom: 0,
-    backgroundColor: bgColorBase,
-    display: 'flex',
-    justifyContent: 'space-between'
-  },
   arrow: {
     width: 32,
     height: 32,

--- a/src/forms/SubmissionDetail.jsx
+++ b/src/forms/SubmissionDetail.jsx
@@ -128,7 +128,7 @@ export default class SubmissionDetail extends Component {
   }
 
   renderAuthorDetail() {
-    const { submission, submissionId, onFlag, onBookmark } = this.props;
+    const { submission, onFlag, onBookmark } = this.props;
     const authorDetails = submission.replies
       .filter(({ identity }) => identity === true)
       .map(reply => ({
@@ -141,7 +141,7 @@ export default class SubmissionDetail extends Component {
       <div>
         <div style={styles.authorHeaderContainer}>
           <div style={styles.authorHeaderInfo}>
-            <span style={styles.subNum}>{submissionId}</span> {moment(submission.date_created).format('L LT')}
+            <span style={styles.subNum}>{submission.number || ''}</span> {moment(submission.date_created).format('L LT')}
           </div>
           <div style={styles.headerButtons}>
             <Button
@@ -242,7 +242,7 @@ const styles = {
     marginRight: 20
   },
   subNum: {
-    fontSize: '1.2em',
+    fontSize: '1.5em',
     marginRight: 10,
     fontWeight: 'bold'
   },

--- a/src/forms/SubmissionListSidebar.js
+++ b/src/forms/SubmissionListSidebar.js
@@ -70,7 +70,7 @@ export default class Sidebar extends Component {
             styles.submissionContainer,
             submission.id === activeSubmission && styles.activeSubmission
           ]} key={key}>
-          <span style={{fontWeight: 'bold'}}>{key + 1}</span>
+          <span style={{fontWeight: 'bold'}}>{submission.number || ''}</span>
           <span>{moment(submission.date_created).format('L LT')}</span>
           <div>
             <span key={`${key}-0`} style={[styles.iconContainer(hasFlag(submission, 'flagged'),
@@ -133,7 +133,7 @@ export default class Sidebar extends Component {
         </div>
         <div>{this.listSubmissions(submissions, activeSubmission, onSelect)}</div>
         { form ? <Pagination current={subPageOffset}
-          total={Math.ceil(form.stats.responses / 10)}
+          total={Math.ceil(formCounts.totalSearch / 10)}
           onChange={this.paginate.bind(this)} /> : null }
       </div>
     );


### PR DESCRIPTION
## What does this PR do?

fixes https://github.com/coralproject/ask/issues/30

also hides the Pagination component if the count is `<= 10`.

## How do I test this PR?

- go to the Submission Manager for a form
- click through. the number on the Submission List on the left should match the Submission Detail on the right
- find a form that has more than 10 submissions
- you should be able to paginate as normal
- filter the submissions so there are < 10. the pagination tool should disappear.

@coralproject/frontend

…e DBO. Pagination converted back to stateful component for styling with Radium