### PR TITLE
make sure router works if not logged in on Saved Searches page

### DIFF
--- a/src/app/SeeAllSearches.jsx
+++ b/src/app/SeeAllSearches.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import { connect } from 'react-redux';
 import {Link} from 'react-router';
@@ -21,6 +21,10 @@ class SeeAllSearches extends React.Component {
   constructor(props) {
     super(props);
     this.state = { deleteModalOpen: false };
+  }
+
+  static contextTypes = {
+    router: PropTypes.object.isRequired
   }
 
   componentWillMount() {


### PR DESCRIPTION
## What does this PR do?

if `requireLogin` is set to true, and you're not logged in, `react-router` tries to redirect you. But the `router` object is missing from context.

## How do I test this PR?

- make sure `requireLogin` is set to true in your config and load cay in Incognito mode
- does the app redirect you to the login screen?

@coralproject/frontend

