### PR TITLE
disable inactive message box

### DIFF
--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -201,11 +201,12 @@ export default class FormChrome extends React.Component {
                   style={styles.closeRadio}
                   checked={form.status === 'closed'}
                   onClick={this.props.updateStatus} />
+                {/*
                 <textarea
                   onChange={this.setInactiveMessage.bind(this)}
                   style={styles.statusMessage}
                   defaultValue={form.settings.inactiveMessage}></textarea>
-                <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>
+                <p>The message will appear to readers when you close the form and are no longer collecting submissions.</p>*/}
                 <div style={this.getLoaderStyles(this, true)}></div>
                 <div style={this.getLoaderStyles()}></div>
               </div>


### PR DESCRIPTION
## What does this PR do?

disables editing the Inactive Message so some bugs aren't super obvious before the demo.

## How do I test this PR?

- open a form.
- click the status dropdown
- the inactive message textarea should be hidden

@coralproject/frontend

