### PR TITLE
filter ranges not loading fix

### DIFF
--- a/src/filters/FilterNumbers.jsx
+++ b/src/filters/FilterNumbers.jsx
@@ -73,13 +73,13 @@ export default class FilterNumbers extends React.Component {
             onChange={event => this.props.onChange(this.props.fieldName, 'userMin', +event.target.value)}
             style={styles.minMaxInputs}
             type='number'
-            value={this.props.userMin}/>
+            value={this.props.userMin === null ? '' : this.props.userMin}/>
           {` - `}
           <input
             onChange={event => this.props.onChange(this.props.fieldName, 'userMax', +event.target.value)}
             style={styles.minMaxInputs}
             type='number'
-            value={this.props.userMax}/>
+            value={this.props.userMax === null ? '' : this.props.userMax}/>
         </div>
         <p style={{marginTop: 10, color: 'red'}}>{this.renderHelpText()}</p>
         </div>
@@ -103,6 +103,5 @@ const styles = {
     border: '1px solid lightgrey',
     borderRadius: 3,
     fontSize: 16
-  },
-
+  }
 };

--- a/src/filters/FiltersActions.js
+++ b/src/filters/FiltersActions.js
@@ -3,14 +3,9 @@
  * Module dependencies
  */
 
-import reduce from 'lodash/collection/reduce';
-import has from 'lodash/object/has';
-import isString from 'lodash/lang/isString';
-import isDate from 'lodash/lang/isDate';
 import isUndefined from 'lodash/lang/isUndefined';
 import isNull from 'lodash/lang/isNull';
 import template from 'lodash/string/template';
-import { clamp } from 'components/utils/math';
 import { xenia } from 'app/AppActions';
 import { makeQueryFromState } from 'search/SearchActions';
 import { parseFilterRanges, distributionForInput } from 'filters/utils';

--- a/src/filters/UserFilters.jsx
+++ b/src/filters/UserFilters.jsx
@@ -130,7 +130,6 @@ export default class UserFilters extends React.Component {
             type={f.type}/>
         );
       } else if (f.type === 'intRange' || f.type === 'floatRange') {
-        // capitalize first letter of description
         filterComponent = (
           <FilterNumbers
             style={filterStyle}

--- a/src/filters/utils.js
+++ b/src/filters/utils.js
@@ -5,6 +5,11 @@
 
 import isUndefined from 'lodash/lang/isUndefined';
 import isNull from 'lodash/lang/isNull';
+import reduce from 'lodash/collection/reduce';
+import has from 'lodash/object/has';
+import isString from 'lodash/lang/isString';
+import isDate from 'lodash/lang/isDate';
+import { clamp } from 'components/utils/math';
 
 // TODO: refactor this function. It's large and hard to understand
 export const parseFilterRanges = (ranges, filterState) =>


### PR DESCRIPTION
## What does this PR do?

The filter ranges were never being loaded correctly because of some missing imports in the new `filters/utils.js` file that were failing silently.
## How do I test this PR?
- go to Create Search page
- all filters from `data_config.json` should be displayed, and the ranges should load after a second.

@coralproject/frontend
