### PR TITLE
Allowing for customization of Other text

### DIFF
--- a/src/forms/editors/MultipleChoiceEditor.jsx
+++ b/src/forms/editors/MultipleChoiceEditor.jsx
@@ -91,6 +91,13 @@ export default class MultipleChoiceEditor extends Component {
     this.props.onEditorChange(updatedField);
   }
 
+  onOtherTextChange(e) {
+    let { field } = this.props;
+    let updatedProps = Object.assign({}, field.props, { otherText: e.target.value });
+    let updatedField = Object.assign({}, field, { props: updatedProps });
+    this.props.onEditorChange(updatedField);
+  }
+
   getOptions() {
     return this.state.options.map((option, i) => {
       return (
@@ -143,7 +150,7 @@ export default class MultipleChoiceEditor extends Component {
             field.props.otherAllowed ?
               <div style={ styles.optionRow }>
                 <div style={ styles.optionRowText }>
-                  <span style={ styles.otherSample }>Other</span>
+                  <input style={ styles.optionInput } type="text" defaultValue="Other:" value={ field.props.otherText } onChange={ this.onOtherTextChange.bind(this) } />
                 </div>
                 <div style={ styles.optionRowButtons }>
                   &nbsp;


### PR DESCRIPTION
## What does this PR do?
- Enables customization of the "Other:" text in Multiple Choice fields.
## How do I test this PR?
- Make sure to be on **customize-other-text** branch both on Elkhorn and Cay.
- Go to **Create form**
- Add a Multiple Choice field and enable "Other". Change the default text.
- Preview the form -> it should show your custom text.

@coralproject/frontend
