### PR TITLE
Remove form chrome on form creator

### DIFF
--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -152,28 +152,26 @@ export default class FormChrome extends React.Component {
 
         <p style={styles.formName}>{name}</p>
 
-        <div style={styles.formControls}>
-          <div key="huey" style={[
-            styles.option,
-            this.props.activeTab === 'builder' && styles.active]}
-            onClick={this.buildForm.bind(this)}>
-            {this.props.create ? 'Build Form' : 'Edit Form'}
-          </div>
-          <div key="dewey" style={[
-            styles.option,
-            activeTab === 'submissions' && styles.active,
-            create && styles.disabled]}
-            onClick={this.reviewSubmissions.bind(this)}>
-            Submissions {this.submissionBadge()}
-          </div>
-          <div key="louie" style={[
-            styles.option,
-            activeTab === 'gallery' && styles.active,
-            create && styles.disabled]}
-            onClick={this.manageGallery.bind(this)}>
-            Gallery {this.galleryBadge()}
-          </div>
-        </div>
+        {!create ?
+          <div style={styles.formControls}>
+            <div key="huey" style={[
+              styles.option,
+              this.props.activeTab === 'builder' && styles.active]}
+              onClick={this.buildForm.bind(this)}> Edit Form
+            </div>
+            <div key="dewey" style={[
+              styles.option,
+              activeTab === 'submissions' && styles.active]}
+              onClick={this.reviewSubmissions.bind(this)}>
+              Submissions {this.submissionBadge()}
+            </div>
+            <div key="louie" style={[
+              styles.option,
+              activeTab === 'gallery' && styles.active]}
+              onClick={this.manageGallery.bind(this)}>
+              Gallery {this.galleryBadge()}
+            </div>
+          </div> : null }
 
         {
           form ?


### PR DESCRIPTION
## What does this PR do?

Removes the only non-clickable button on the form create chrome
## How do I test this PR?
- Go to form create
- There shouldn't be the Build form non-clickable button anymore

@coralproject/frontend
