### PR TITLE
Fixed submissions form list sort

### DIFF
--- a/src/app/FormList.jsx
+++ b/src/app/FormList.jsx
@@ -117,7 +117,7 @@ const FormTable = ({ loadingTags, forms, onRowClick, confirmDeletion, onCopyForm
   <DataTable style={styles.table} sortable rows={forms.map(formatForm)}>
     <TableHeader cellFormatter={(n, r, i) => <span style={styles.name}  onClick={() => onRowClick(forms[i].id)}>{n}</span>} name="name">{ L.t('Name') }</TableHeader>
     <TableHeader name="description">{ L.t('Description') }</TableHeader>
-    <TableHeader cellFormatter={n => <span style={styles.submission}>{n}</span>} numeric name="submissions">{ L.t('Submissions') }</TableHeader>
+    <TableHeader sortFn={(a, b, asc) => asc ? b - a : a - b} cellFormatter={n => <span style={styles.submission}>{n}</span>} numeric name="submissions">{ L.t('Submissions') }</TableHeader>
     <TableHeader cellFormatter={date => moment(date).format('L')} name="date_created">{ L.t('Creation date') }</TableHeader>
     <TableHeader nosort name="copy" style={styles.rowActions} cellFormatter={i => <IconButton name='content_copy' onClick={e => onCopyFormClick(forms[i], e)}/>}></TableHeader>
     <TableHeader nosort style={styles.rowActions} name="remove"


### PR DESCRIPTION
## What does this PR do?
- Fixes the submission field sorting on the form list table
## How do I test this PR?
- Go to the form list
- Sort by submissions
- It should sort as expected (before it was lexicographic)

@coralproject/frontend
