### PR TITLE
search submissions on Enter

### DIFF
--- a/src/forms/SubmissionListSidebar.js
+++ b/src/forms/SubmissionListSidebar.js
@@ -139,7 +139,11 @@ export default class Sidebar extends Component {
             <p style={styles.count}>{count} of {formCounts.totalSubmissions} Submission{formCounts.totalSubmissions === 1 ? '' : 's'}</p>
           </div>
           <div style={styles.searchContainer}>
-            <input style={styles.search} type='text' value={search}
+            <input
+              style={styles.search}
+              type='text'
+              value={search}
+              onKeyUp={e => { if (e.key === 'Enter') this.props.onSearchChange(search); }}
               onChange={evt => this.setState({ search: evt.target.value })}
               placeholder='Search' />
             <button onClick={() => this.props.onSearchChange(search)}
@@ -161,9 +165,13 @@ export default class Sidebar extends Component {
             onChange={this.props.onOrderChange} />
         </div>
         <div>{this.listSubmissions(submissions, activeSubmission, onSelect)}</div>
-        { form ? <Pagination current={subPageOffset}
-          total={Math.ceil(count / 10)}
-          onChange={this.paginate.bind(this, count)} /> : null }
+        {
+          form
+          ? <Pagination current={subPageOffset}
+              total={Math.ceil(count / 10)}
+              onChange={this.paginate.bind(this, count)} />
+          : null
+        }
       </div>
     );
   }


### PR DESCRIPTION
## What does this PR do?

fixes https://github.com/coralproject/ask/issues/53

This should allow searching Submissions after hitting the Enter key while the search `<input>` field has focus.

Caveat: I'm not sure the search is working at all. The url looks correct, but the result set is empty. Search 'buffalo' here: `http://localhost:3000/forms/57955fe7d05a1e00059dbff3/submissions`
## How do I test this PR?
- Go to submissions list screen with some submissions with text
- type something into the search box
- hit `Enter` on the keyboard while the input field has focus.

@coralproject/frontend
