### PR TITLE
Drag and drop breaking fix

### DIFF
--- a/src/forms/FormField.js
+++ b/src/forms/FormField.js
@@ -124,14 +124,14 @@ export default class FormField extends Component {
     );
   }
 
-  getIcon(component) {
-    return askTypes.find(type => type.type === component).icon;
+  getIcon(field) {
+    return askTypes.find(type => type.type === field[field.component ? 'component' : 'type']).icon;
   }
 
   renderContainer() {
     const { id, onMove, isLast, position, onDelete, onDuplicate } = this.props;
     const { field } = this.state;
-    const FieldIcon = this.getIcon(field.component);
+    const FieldIcon = this.getIcon(field);
     const fieldTitle = field.title ? field.title : 'Ask readers a question';
     const requiredMark = field.wrapper && field.wrapper.required ? <span style={ styles.requiredAsterisk }>*</span> : null;
     const identityMark = field.identity ? <span style={ styles.identityLabel }><FaUser/></span> : null;


### PR DESCRIPTION
## What does this PR do?
- Fixes: `FormField.js:128 Uncaught TypeError: Cannot read property 'icon' of undefinedvalue @ FormField.js...` (reported on Slack).
## How do I test this PR?

This is happening on `master` while dragging new elements to the form fields container.
- Go to **Create form**
- Drag elements from the toolbox to the drop area
- Try some dragging and reordering of the fields
- Should work as expected

@coralproject/frontend
