### PR TITLE
Ask 101 - Placeholder instead of text

### DIFF
--- a/src/forms/editors/MultipleChoiceEditor.jsx
+++ b/src/forms/editors/MultipleChoiceEditor.jsx
@@ -150,7 +150,7 @@ export default class MultipleChoiceEditor extends Component {
             field.props.otherAllowed ?
               <div style={ styles.optionRow }>
                 <div style={ styles.optionRowText }>
-                  <input style={ styles.optionInput } type="text" defaultValue="Other:" value={ field.props.otherText } onChange={ this.onOtherTextChange.bind(this) } />
+                  <input style={ styles.optionInput } type="text" placeholder="Other:" value={ field.props.otherText } onChange={ this.onOtherTextChange.bind(this) } />
                 </div>
                 <div style={ styles.optionRowButtons }>
                   &nbsp;

--- a/src/forms/editors/MultipleChoiceEditor.jsx
+++ b/src/forms/editors/MultipleChoiceEditor.jsx
@@ -115,7 +115,7 @@ export default class MultipleChoiceEditor extends Component {
                   }
                 }
               }
-              style={ styles.optionInput } type="text" value={ option.title } onChange={ this.updateOption.bind(this, i) } />
+              style={ styles.optionInput } type="text" placeholder={ option.title } onChange={ this.updateOption.bind(this, i) } />
           </div>
 
           {/* Action buttons for an option */}


### PR DESCRIPTION
## What does this PR do?

This PR solves issue Ask-101. 

Issue description:

> Multiple choice "Option A" and "Other" text should disappear on click (hints vs text)

https://github.com/coralproject/ask/issues/101
## How do I test this PR?
- Go to Create Form
- Select Multiple Choice
- Add Options

You should be able to set the title of the option without deleting the placeholder "Option 1"

@coralproject/frontend
