### PR TITLE
Showing only publish options for gallery if it was published. Also re…

### DIFF
--- a/src/app/GalleryManager.jsx
+++ b/src/app/GalleryManager.jsx
@@ -239,6 +239,7 @@ export default class GalleryManager extends Component {
   createEmbed(type) {
     const {forms} = this.props;
     const gallery = forms[forms.activeGallery];
+
     if (!gallery) return;
 
     switch (type) {
@@ -390,6 +391,7 @@ export default class GalleryManager extends Component {
               <PublishOptions
                  form={form}
                  forms={forms}
+                 hideOptions={!forms.activeGallery || !forms[forms.activeGallery].config.baseUrl}
                  activeForm={forms.activeForm}
                  onOpenPreview={this.togglePreview.bind(this)}
                  onSaveClick={this.onSaveClick.bind(this)}

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -534,10 +534,10 @@ export const publishGallery = () => (dispatch, getState) => {
   })
   .then(res => res.json())
   .then(gallery => {
-    console.log(gallery);
     dispatch({type: PUBLISH_GALLERY_SUCCESS, gallery});
     return gallery;
   })
+  .then(gallery => dispatch(fetchGallery(forms.activeForm)))
   .catch(error => dispatch({type: PUBLISH_GALLERY_FAILURE, error}));
 };
 

--- a/src/forms/PublishOptions.jsx
+++ b/src/forms/PublishOptions.jsx
@@ -79,7 +79,7 @@ export default class PublishOptions extends Component {
 
   render() {
 
-    const { onOpenPreview, forms, activeForm, onSaveClick, iframeCode, scriptCode, standaloneCode } = this.props;
+    const { onOpenPreview, forms, activeForm, onSaveClick, iframeCode, scriptCode, standaloneCode, hideOptions } = this.props;
 
     return (
       <div style={styles.leftPan}>
@@ -99,7 +99,7 @@ export default class PublishOptions extends Component {
             </Button>
 
             {
-              activeForm
+              activeForm && !hideOptions
               ? <Button
                   style={{ width: 310, marginTop: 10, backgroundColor: '#353B43' }}
                   raised ripple accent


### PR DESCRIPTION
## What does this PR do?

Before publishing a gallery for the first time the publish options was showing "undefined" on the embed codes. This pr does the following:
- If a gallery was never published the `publish options` button does not appear
- After publishing we fetch the gallery data so we can rehydrate the gallery model :)
## How do I test this PR?
- Create a form
- Go to the gallery
- The publish options button shouldn't appear
- Publish the gallery (save)
- The publish button should appear and the embed codes should be correct

@coralproject/frontend
