### PR TITLE
restrict drag target to left bar

### DIFF
--- a/src/forms/FormField.js
+++ b/src/forms/FormField.js
@@ -130,7 +130,7 @@ export default class FormField extends Component {
   }
 
   render() {
-    return this.props.connectDragSource(
+    return (
       <div onMouseDown={ this.onMouseDown.bind(this) }>
         { this.renderContainer() }
       </div>
@@ -142,7 +142,7 @@ export default class FormField extends Component {
   }
 
   renderContainer() {
-    const { id, onMove, isLast, position, onDelete, onDuplicate } = this.props;
+    const { id, onMove, isLast, position, onDelete, onDuplicate, connectDragSource } = this.props;
     const { field } = this.state;
     const FieldIcon = this.getIcon(field);
     const fieldTitle = field.title ? field.title : 'Ask readers a question';
@@ -151,7 +151,7 @@ export default class FormField extends Component {
 
     return (
       <div className={field.component + ' ' + id} style={ styles.fieldContainer(!this.props.isDragging && this.state.expanded) } key={ id }>
-        <div style={ styles.fieldPosition }>{ position + 1 }</div>
+        {connectDragSource(<div style={ styles.fieldPosition }>{ position + 1 }</div>)}
         <div style={ styles.fieldIcon }><FieldIcon /></div>
         <div style={ styles.fieldContents }>
 
@@ -385,6 +385,8 @@ export const styles = {
     background: 'none'
   },
   fieldPosition: {
+    background: 'repeating-linear-gradient( -45deg, #dbdbdb, #dbdbdb 10px, #eee 10px, #eee 20px )',
+    cursor: 'move',
     alignSelf: 'flex-start',
     fontWeight: 'normal',
     padding: '15px 15px',


### PR DESCRIPTION
## What does this PR do?

drag was being triggered when you selected text fields, and indeed when you moved your mouse with the button down even if only for a few pixels. This was very annoying.

This PR makes the drag target only underneath the left side of the widgets, and adds some visual indication of where the target is.

![screen shot 2016-09-14 at 1 49 11 pm](https://cloud.githubusercontent.com/assets/282503/18527447/0a2050dc-7a82-11e6-9e2c-963e9aef85f1.png)
## How do I test this PR?
- try to reorder questions in a form with the sidebar target
- try to drag when a question is expanded
- try to move a new question out. should work the same as before.

@coralproject/frontend
