### PR TITLE
Updating promise testing in TagActions

### DIFF
--- a/test/tags/TagActions.spec.js
+++ b/test/tags/TagActions.spec.js
@@ -202,7 +202,7 @@ describe('TagActions', () => {
         });
     });
 
-    it('should return an TAG_REQUEST_FAILURE when json from server is improperly formatted', (done) => {
+    it('should return an TAG_REQUEST_FAILURE when json from server is improperly formatted', () => {
       fetchMock.restore();
       fetchMock.mock((url, opts) => {
         if (url === 'trustHost/api/tag' && opts.method === 'POST') {
@@ -210,15 +210,14 @@ describe('TagActions', () => {
         } else {
           return false;
         }
-      }, 'The Trust service is pissed yo'); // Todo: update jive, don't know what's going down
-      TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
+      }, 'JSON improperly formatted');
+      return TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_FAILURE);
           expect(action).to.have.property('err')
-            .and.to.deep.equal('Error from trust: Trust is pissed yo');
-          done();
+            .and.to.deep.equal('Error from the Trust service: JSON improperly formatted');
         });
     });
 

--- a/test/tags/TagActions.spec.js
+++ b/test/tags/TagActions.spec.js
@@ -206,8 +206,7 @@ describe('TagActions', () => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_FAILURE);
-          expect(action).to.have.property('err')
-            .and.to.deep.equal('Error from the Trust service: JSON improperly formatted');
+          expect(action).to.have.property('err');
         });
     });
 

--- a/test/tags/TagActions.spec.js
+++ b/test/tags/TagActions.spec.js
@@ -45,38 +45,35 @@ describe('TagActions', () => {
 
     });
 
-    it('should dispatch a TAG_REQUEST_STARTED action', (done) => {
-      TagActions.getTags()(store.dispatch, store.getState)
+    it('should dispatch a TAG_REQUEST_STARTED action', () => {
+      return TagActions.getTags()(store.dispatch, store.getState)
         .then(() => {
           expect(store.getActions()[0]).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_STARTED);
-          done();
         });
     });
 
-    it ('should dispatch a TAG_REQUEST_SUCCESS action with the retrieved tags on success', (done) => {
-      TagActions.getTags()(store.dispatch, store.getState)
+    it ('should dispatch a TAG_REQUEST_SUCCESS action with the retrieved tags on success', () => {
+      return TagActions.getTags()(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_SUCCESS);
           expect(action).to.have.property('payload')
             .and.to.deep.equal({tags:['tag1','tag2']});
-          done();
         });
     });
 
-    it ('should dispatch a TAG_REQUEST_FAILURE action on failure', (done) => {
+    it ('should dispatch a TAG_REQUEST_FAILURE action on failure', () => {
       fetchMock.restore();
       fetchMock.mock('trustHost/api/tags', {status:404});
-      TagActions.getTags()(store.dispatch, store.getState)
+      return TagActions.getTags()(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_FAILURE);
           expect(action).to.have.property('err')
             .and.to.equal('404 Not Found');
-          done();
         });
     });
   });
@@ -95,39 +92,36 @@ describe('TagActions', () => {
 
     });
 
-    it('should make a properly formatted DELETE request', (done) => {
+    it('should make a properly formatted DELETE request', () => {
       fetchMock.restore();
       fetchMock.mock((url, opts) => {
         expect(url).to.equal('trustHost/api/tag');
         expect(opts.method).to.equal('DELETE');
-        done();
         return true;
       },200);
-      TagActions.deleteTag()(store.dispatch, store.getState);
+      return TagActions.deleteTag()(store.dispatch, store.getState);
     });
 
-    it('should dispatch a TAG_REQUEST_STARTED action', (done) => {
-      TagActions.deleteTag('test_tag','test tag description', 123)(store.dispatch, store.getState)
+    it('should dispatch a TAG_REQUEST_STARTED action', () => {
+      return TagActions.deleteTag('test_tag','test tag description', 123)(store.dispatch, store.getState)
         .then(() => {
           expect(store.getActions()[0]).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_STARTED);
-          done();
         });
     });
 
-    it('should dispatch a TAG_REQUEST_SUCCESS action when successful', (done) => {
-      TagActions.deleteTag('test_tag','test tag description', 123)(store.dispatch, store.getState)
+    it('should dispatch a TAG_REQUEST_SUCCESS action when successful', () => {
+      return TagActions.deleteTag('test_tag','test tag description', 123)(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_SUCCESS);
           expect(action).to.have.property('index')
             .and.to.equal(123);
-          done();
         });
     });
 
-    it ('should dispatch a TAG_REQUEST_FAILURE action on failure', (done) => {
+    it ('should dispatch a TAG_REQUEST_FAILURE action on failure', () => {
       fetchMock.restore();
       fetchMock.mock((url, opts) => {
         if (url === 'trustHost/api/tag' && opts.method === 'DELETE') {
@@ -136,14 +130,13 @@ describe('TagActions', () => {
           return false;
         }
       },{status:404});
-      TagActions.deleteTag('test_tag','test tag description', 123)(store.dispatch, store.getState)
+      return TagActions.deleteTag('test_tag','test tag description', 123)(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_FAILURE);
           expect(action).to.have.property('err')
             .and.to.equal('404 Not Found');
-          done();
         });
     });
   });
@@ -161,7 +154,7 @@ describe('TagActions', () => {
       },JSON.stringify(mocktag));
     });
 
-    it('should make a properly formatted POST request', (done) => {
+    it('should make a properly formatted POST request', () => {
       fetchMock.restore();
       fetchMock.mock((url, opts) => {
         expect(url).to.equal('trustHost/api/tag');
@@ -171,23 +164,21 @@ describe('TagActions', () => {
         expect(body.name).to.equal(mocktag.name);
         expect(body.description).to.equal(mocktag.description);
         expect(body.old_name).to.equal(mocktag.old_name);
-        done();
         return true;
       },200);
-      TagActions.storeTag(mocktag.name, mocktag.description, mocktag.index, mocktag.old_name)(store.dispatch, store.getState);
+      return TagActions.storeTag(mocktag.name, mocktag.description, mocktag.index, mocktag.old_name)(store.dispatch, store.getState);
     });
 
-    it('should dispatch a TAG_REQUEST_STARTED action', (done) => {
-      TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
+    it('should dispatch a TAG_REQUEST_STARTED action', () => {
+      return TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
         .then(() => {
           expect(store.getActions()[0]).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_STARTED);
-          done();
         });
     });
 
-    it('should dispatch a TAG_REQUEST_SUCCESS action with the stored tag when successful', (done) => {
-      TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
+    it('should dispatch a TAG_REQUEST_SUCCESS action with the stored tag when successful', () => {
+      return TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
@@ -198,7 +189,6 @@ describe('TagActions', () => {
             .and.to.equal(123);
           expect(action).to.have.property('requestType')
             .and.to.equal('create');
-          done();
         });
     });
 
@@ -221,7 +211,7 @@ describe('TagActions', () => {
         });
     });
 
-    it ('should dispatch a TAG_REQUEST_FAILURE action on failure', (done) => {
+    it ('should dispatch a TAG_REQUEST_FAILURE action on failure', () => {
       fetchMock.restore();
       fetchMock.mock((url, opts) => {
         if (url === 'trustHost/api/tag' && opts.method === 'POST') {
@@ -230,14 +220,13 @@ describe('TagActions', () => {
           return false;
         }
       },{status:404});
-      TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
+      return TagActions.storeTag(mocktag.name,mocktag.description, mocktag.index)(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.TAG_REQUEST_FAILURE);
           expect(action).to.have.property('err')
             .and.to.equal('404 Not Found');
-          done();
         });
     });
 
@@ -248,12 +237,11 @@ describe('TagActions', () => {
       fetchMock.mock('trustHost/api/tags',JSON.stringify([mocktag,mocktag2]));
     });
 
-    it('should disptach a REQUEST_ALL_TAGS action', (done) => {
-      TagActions.fetchAllTags()(store.dispatch, store.getState)
+    it('should disptach a REQUEST_ALL_TAGS action', () => {
+      return TagActions.fetchAllTags()(store.dispatch, store.getState)
         .then(() => {
           expect(store.getActions()[0]).to.have.property('type')
             .and.to.equal(TagActions.REQUEST_ALL_TAGS);
-          done();
         });
     });
 
@@ -268,29 +256,27 @@ describe('TagActions', () => {
       expect(TagActions.fetchAllTags()(store.dispatch, store.getState)).to.be.false;
     });
 
-    it('should dispatch a RECEIVE_ALL_TAGS action with tags on success', (done) => {
-      TagActions.fetchAllTags()(store.dispatch, store.getState)
+    it('should dispatch a RECEIVE_ALL_TAGS action with tags on success', () => {
+      return TagActions.fetchAllTags()(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.RECEIVE_ALL_TAGS);
           expect(action).to.have.property('tags')
             .and.to.deep.equal([mocktag,mocktag2]);
-          done();
         });
     });
 
     it('should dispatch an ALL_TAGS_REQUEST_ERROR action on failure', () => {
       fetchMock.restore();
       fetchMock.mock('trustHost/api/tags',{status:404});
-      TagActions.fetchAllTags()(store.dispatch, store.getState)
+      return TagActions.fetchAllTags()(store.dispatch, store.getState)
         .then(() => {
           let action = store.getActions()[1];
           expect(action).to.have.property('type')
             .and.to.equal(TagActions.ALL_TAGS_REQUEST_ERROR);
           expect(action).to.have.property('err')
             .and.to.deep.equal('404 Not Found');
-          done();
         });
     });
   });


### PR DESCRIPTION
## What does this PR do?
- Fixes a test that broke with the upgrade to the new API.
- Makes the failing test agnostic to error language (a change in this language caused the problem.)
- Updates promise tests to provide clearer errors in general.
