### PR TITLE
remove isActive from codebase. auto-save after updating form status

### DIFF
--- a/src/app/FormCreate.jsx
+++ b/src/app/FormCreate.jsx
@@ -38,23 +38,17 @@ export default class FormCreate extends Component {
     }
   }
 
-  updateFormStatus(status) {
-    this.props.dispatch(updateForm({status}));
-    this.props.dispatch(updateFormSettings({ isActive: status === 'open' }));
-  }
-
   updateInactive(value) {
     this.props.dispatch(updateFormSettings({ inactiveMessage: value }));
   }
 
   render() {
     const { preview } = this.state;
-    const { forms } = this.props;
     return (
       <Page style={styles.page}>
-        <FormChrome form={forms.form}
+        <FormChrome form={null}
           create={true}
-          updateStatus={this.updateFormStatus.bind(this)}
+          updateStatus={() => null}
           updateInactive={this.updateInactive.bind(this)}
           activeTab="builder" />
         <div style={styles.formBuilderContainer}>

--- a/src/app/FormEdit.jsx
+++ b/src/app/FormEdit.jsx
@@ -13,6 +13,7 @@ import {
   updateFormStatus,
   requestEditAccess,
   leavingEdit,
+  saveForm,
   updateFormSettings,
   fetchForm } from 'forms/FormActions';
 
@@ -35,6 +36,11 @@ export default class FormEdit extends Component {
     props.dispatch(fetchForm(id));
     props.dispatch(fetchGallery(id));
     props.dispatch(fetchSubmissions(id));
+
+    this.updateFormStatus = this.updateFormStatus.bind(this);
+    this.onClosePreview = this.onClosePreview.bind(this);
+    this.showPreview = this.showPreview.bind(this);
+    this.updateInactive = this.updateInactive.bind(this);
   }
 
   componentWillMount() {
@@ -64,7 +70,11 @@ export default class FormEdit extends Component {
   }
 
   updateFormStatus(value) {
-    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
+    const {dispatch, forms} = this.props;
+    // hack. this needs to be fixed.
+    dispatch(updateFormStatus(forms.activeForm, value)).then(updatedForm => {
+      dispatch(saveForm(updatedForm, forms.widgets));
+    });
   }
 
   updateInactive(value) {
@@ -73,9 +83,8 @@ export default class FormEdit extends Component {
 
   render() {
     const { forms, route } = this.props;
-    const { submissionList, activeSubmission, activeForm, activeGallery } = forms;
+    const { submissionList, activeForm, activeGallery } = forms;
     const submissions = submissionList.map(id => forms[id]);
-    const submission = forms[activeSubmission];
     const form = forms[activeForm];
     const gallery = forms[activeGallery];
 
@@ -83,8 +92,8 @@ export default class FormEdit extends Component {
       <Page>
         <FormChrome
           activeTab="builder"
-          updateStatus={this.updateFormStatus.bind(this)}
-          updateInactive={this.updateInactive.bind(this)}
+          updateStatus={this.updateFormStatus}
+          updateInactive={this.updateInactive}
           gallery={gallery}
           submissions={submissions}
           form={form}/>
@@ -93,8 +102,8 @@ export default class FormEdit extends Component {
             form ?
               <FormBuilder
                 activeForm={ forms.activeForm }
-                onClosePreview={this.onClosePreview.bind(this)}
-                onOpenPreview={ this.showPreview.bind(this) }
+                onClosePreview={this.onClosePreview}
+                onOpenPreview={ this.showPreview }
                 route={ route }
                 preview={this.state.preview} />
             : null

--- a/src/app/GalleryManager.jsx
+++ b/src/app/GalleryManager.jsx
@@ -3,6 +3,7 @@ import Radium from 'radium';
 import { connect } from 'react-redux';
 import {
   fetchForm,
+  saveForm,
   fetchGallery,
   fetchSubmissions,
   removeFromGallery,
@@ -148,7 +149,10 @@ export default class GalleryManager extends Component {
   }
 
   updateFormStatus(value) {
-    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
+    const {dispatch, forms} = this.props;
+    dispatch(updateFormStatus(forms.activeForm, value)).then(updatedForm => {
+      dispatch(saveForm(updatedForm, forms.widgets));
+    });
   }
 
   getAttributionFields(form) {

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -17,7 +17,7 @@ import {
   removeFromGallery,
   updateFormStatus,
   fetchForm,
-  updateForm,
+  saveForm,
   updateFormSettings,
   updateOrder,
   updateSearch,
@@ -44,6 +44,18 @@ export default class SubmissionList extends Component {
     dispatch(fetchForm(params.id));
     dispatch(fetchGallery(params.id));
     dispatch(fetchSubmissions(params.id));
+
+    this.updateFormStatus = this.updateFormStatus.bind(this);
+    this.updateInactive = this.updateInactive.bind(this);
+    this.onSubmissionSelect = this.onSubmissionSelect.bind(this);
+    this.onFilterByChange = this.onFilterByChange.bind(this);
+    this.onOrderChange = this.onOrderChange.bind(this);
+    this.onSearchChange = this.onSearchChange.bind(this);
+    this.onFlag = this.onFlag.bind(this);
+    this.onBookmark = this.onBookmark.bind(this);
+    this.onDownloadCSV = this.onDownloadCSV.bind(this);
+    this.removeFromGallery = this.removeFromGallery.bind(this);
+    this.sendToGallery = this.sendToGallery.bind(this);
   }
 
   sendToGallery(galleryId, subId, key) {
@@ -63,7 +75,10 @@ export default class SubmissionList extends Component {
   }
 
   updateFormStatus(value) {
-    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
+    const {dispatch, forms} = this.props;
+    dispatch(updateFormStatus(forms.activeForm, value)).then(updatedForm => {
+      dispatch(saveForm(updatedForm, forms.widgets));
+    });
   }
 
   updateInactive(value) {
@@ -103,8 +118,8 @@ export default class SubmissionList extends Component {
         <div style={styles.container}>
           <FormChrome
             activeTab="submissions"
-            updateStatus={this.updateFormStatus.bind(this)}
-            updateInactive={this.updateInactive.bind(this)}
+            updateStatus={this.updateFormStatus}
+            updateInactive={this.updateInactive}
             gallery={gallery}
             submissions={submissions}
             form={form}/>
@@ -115,22 +130,22 @@ export default class SubmissionList extends Component {
             activeSubmission={activeSubmission}
             filterBy={submissionFilterBy}
             order={submissionOrder}
-            onSelect={this.onSubmissionSelect.bind(this)}
-            onFilterByChange={this.onFilterByChange.bind(this)}
-            onOrderChange={this.onOrderChange.bind(this)}
-            onSearchChange={this.onSearchChange.bind(this)}
-            onFlag={this.onFlag.bind(this)}
-            onBookmark={this.onBookmark.bind(this)}
-            onSelect={this.onSubmissionSelect.bind(this)}
-            onDownloadCSV={this.onDownloadCSV.bind(this)} />
+            onSelect={this.onSubmissionSelect}
+            onFilterByChange={this.onFilterByChange}
+            onOrderChange={this.onOrderChange}
+            onSearchChange={this.onSearchChange}
+            onFlag={this.onFlag}
+            onBookmark={this.onBookmark}
+            onSelect={this.onSubmissionSelect}
+            onDownloadCSV={this.onDownloadCSV} />
           <SubmissionDetail
             dispatch={this.props.dispatch}
             submission={submission}
-            removeFromGallery={this.removeFromGallery.bind(this)}
-            sendToGallery={this.sendToGallery.bind(this)}
+            removeFromGallery={this.removeFromGallery}
+            sendToGallery={this.sendToGallery}
             gallery={gallery}
-            onFlag={this.onFlag.bind(this)}
-            onBookmark={this.onBookmark.bind(this)}/>
+            onFlag={this.onFlag}
+            onBookmark={this.onBookmark}/>
         </div>
       </Page>
     );

--- a/src/app/layout/FormChrome.jsx
+++ b/src/app/layout/FormChrome.jsx
@@ -37,6 +37,12 @@ export default class FormChrome extends React.Component {
   constructor(props) {
     super(props);
     this.state = {statusDropdownOpen: false};
+    this.toggleDropdown = this.toggleDropdown.bind(this);
+    this.onApplyClick = this.onApplyClick.bind(this);
+    this.setInactiveMessage = this.setInactiveMessage.bind(this);
+    this.buildForm = this.buildForm.bind(this);
+    this.reviewSubmissions = this.reviewSubmissions.bind(this);
+    this.manageGallery = this.manageGallery.bind(this);
   }
 
   buildForm() { // navigate to the form builder or editor
@@ -187,25 +193,25 @@ export default class FormChrome extends React.Component {
             <div key="huey" style={[
               styles.option,
               this.props.activeTab === 'builder' && styles.active]}
-              onClick={this.buildForm.bind(this)}> Edit Form
+              onClick={this.buildForm}> Edit Form
             </div>
             <div key="dewey" style={[
               styles.option,
               activeTab === 'submissions' && styles.active]}
-              onClick={this.reviewSubmissions.bind(this)}>
+              onClick={this.reviewSubmissions}>
               Submissions {this.submissionBadge()}
             </div>
             <div key="louie" style={[
               styles.option,
               activeTab === 'gallery' && styles.active]}
-              onClick={this.manageGallery.bind(this)}>
+              onClick={this.manageGallery}>
               Gallery {this.galleryBadge()}
             </div>
           </div> : null }
 
         {
           form ?
-            <div style={this.getStatusSelectStyle()} onClick={this.toggleDropdown.bind(this)} className="form-status-toggle" >
+            <div style={this.getStatusSelectStyle()} onClick={this.toggleDropdown} className="form-status-toggle" >
               <span style={ styles.formStatusText }>Form Status:</span>
               {this.getColoredStatus()}
               {this.getAngleBtn()}
@@ -232,11 +238,11 @@ export default class FormChrome extends React.Component {
                   checked={form.status === 'closed'}
                   onClick={this.props.updateStatus} />
                 <textarea
-                  onChange={this.setInactiveMessage.bind(this)}
+                  onChange={this.setInactiveMessage}
                   style={styles.statusMessage}
                   defaultValue={form.settings.inactiveMessage}></textarea>
                 <div style={styles.forceRight}>
-                  <Button raised onClick={ this.onApplyClick.bind(this) }>
+                  <Button raised onClick={ this.onApplyClick }>
                     { forms.savingForm
                       ? <span><Spinner /> </span>
                       : null

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -399,9 +399,14 @@ export const updateFormStatus = (formId, status) => (dispatch, getState) => {
   const {app} = getState();
   const options = {method: 'PUT', mode: 'cors'};
 
-  fetch(`${app.askHost}/v1/form/${formId}/status/${status}`, options)
+  return fetch(`${app.askHost}/v1/form/${formId}/status/${status}`, options)
     .then(res => res.json())
-    .then(form => dispatch({type: FORM_STATUS_UPDATED, form, status}))
+    .then(form => {
+      dispatch({type: FORM_STATUS_UPDATED, form, status});
+      const updatedState = getState();
+      // we want the Promise to evaluate to the saved form.
+      return updatedState.forms[updatedState.forms.activeForm];
+    })
     .catch(error => dispatch({type: FORM_STATUS_UPDATE_ERROR, error}));
 };
 

--- a/src/forms/FormBuilder.js
+++ b/src/forms/FormBuilder.js
@@ -69,7 +69,6 @@ export default class FormBuilder extends Component {
             onOpenPreview={onOpenPreview}
             onPublishOptions={this.onPublishOptions.bind(this)}
             onSaveClick={this.onSaveClick.bind(this)}
-            onFormStatusChange={this.onFormStatusChange.bind(this)}
             addToBottom={this.addToBottom.bind(this)}
             activeForm={activeForm}
             openDialog={this.state.openDialog}
@@ -124,11 +123,6 @@ export default class FormBuilder extends Component {
 
   onPublishOptions() {
     this.setState({ openDialog: !this.state.openDialog });
-  }
-
-  onFormStatusChange(e) {
-    this.markAsUnsaved();
-    this.props.dispatch(updateFormSettings({isActive: e.target.checked}));
   }
 
   onFormTitleChange(e) {

--- a/src/forms/FormBuilderLayout.js
+++ b/src/forms/FormBuilderLayout.js
@@ -79,17 +79,6 @@ const styles = {
     cursor: 'pointer',
     textAlign: 'center'
   },
-  switchSlider: function(isActive) {
-    return {
-      position: 'absolute',
-      width: '280px',
-      left: isActive ? '-80px' : '0px',
-      background: isActive ? '#292' : '#333',
-      transition: 'all .5s',
-      cursor: 'pointer',
-      height: '45px'
-    };
-  },
   switch: {
     position: 'relative',
     height: '42px',

--- a/src/forms/FormBuilderSidebar.js
+++ b/src/forms/FormBuilderSidebar.js
@@ -39,13 +39,6 @@ export default class FormBuilderSidebar extends Component {
     })
   }
 
-  onFormStatusChange(e) {
-    let status = e.target.value;
-    this.setState({ formStatus: status });
-    this.props.dispatch(updateForm({status}));
-    this.props.dispatch(updateFormSettings({ isActive: status === 'open' }));
-  }
-
   onInactiveMessageChange(e) {
     this.props.dispatch(updateFormSettings({ inactiveMessage: e.target.value }));
   }

--- a/src/forms/FormsReducer.js
+++ b/src/forms/FormsReducer.js
@@ -75,7 +75,6 @@ const emptyForm = {
   settings: {
     saveDestination: '',
     showFieldNumbers: true,
-    isActive: false,
     inactiveMessage: 'We are not currently accepting submissions. Thank you.',
     recaptcha: false
   },
@@ -145,8 +144,8 @@ export default (state = initial, action) => {
 
   case types.COPY_FORM:
     let formToCopy = Object.assign({}, state[action.id]);
-    let headerCopy = Object.assign({},formToCopy.header,{title:formToCopy.header.title + ' (Copy)'});
-    let settingsCopy = Object.assign({},formToCopy.settings,{isActive:false});
+    let headerCopy = Object.assign({}, formToCopy.header, {title: formToCopy.header.title + ' (Copy)'});
+    let settingsCopy = Object.assign({}, formToCopy.settings);
     let copiedForm = Object.assign({}, formToCopy,
       {
         header: headerCopy,
@@ -315,9 +314,17 @@ export default (state = initial, action) => {
     return {...state, loadingGallery: false, activeGallery: null, galleryError: action.error};
 
   case types.FORM_STATUS_UPDATED:
-    return {...state, activeForm: action.form.id, [action.form.id]: Object.assign({},
-      action.form, {status: action.status, settings: Object.assign({},
-      action.form.settings, { isActive: action.status === 'open' })})};
+    return {
+      ...state,
+      activeForm: action.form.id,
+      [action.form.id]: {
+        ...action.form,
+        status: action.status,
+        settings: {
+          ...action.form.settings
+        }
+      }
+    };
 
   case types.FORM_ANSWER_SENT_TO_GALLERY:
     return {...state, [action.gallery.id]: action.gallery};

--- a/src/forms/PublishOptions.jsx
+++ b/src/forms/PublishOptions.jsx
@@ -8,7 +8,8 @@ import Spinner from 'components/Spinner';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 import {
-  updateForm,
+  updateFormStatus,
+  saveForm,
   updateFormSettings
  } from 'forms/FormActions';
 
@@ -20,6 +21,10 @@ export default class PublishOptions extends Component {
   constructor(props) {
     super(props);
     this.state = { publishModalOpened: false, formStatus: 'closed', activeTab: 0 };
+
+    this.onFormStatusChange = this.onFormStatusChange.bind(this);
+    this.onInactiveMessageChange = this.onInactiveMessageChange.bind(this);
+    this.togglePublishModal = this.togglePublishModal.bind(this);
   }
 
   togglePublishModal() {
@@ -28,9 +33,11 @@ export default class PublishOptions extends Component {
 
   onFormStatusChange(e) {
     let status = e.target.value;
+    const {dispatch, forms} = this.props;
     this.setState({ formStatus: status });
-    this.props.dispatch(updateForm({status}));
-    this.props.dispatch(updateFormSettings({ isActive: status === 'open' }));
+    this.props.dispatch(updateFormStatus(forms.activeForm, status)).then(updatedForm => {
+      dispatch(saveForm(updatedForm, forms.widgets));
+    });
   }
 
   onInactiveMessageChange(e) {
@@ -45,7 +52,7 @@ export default class PublishOptions extends Component {
       ? <div>
           <h4 style={ styles.dialogSubTitle }>Set form status</h4>
           <RadioGroup
-            onChange={ this.onFormStatusChange.bind(this) }
+            onChange={ this.onFormStatusChange }
             childContainer="div"
             value={ form.status }
             name="formStatusRadio">
@@ -56,7 +63,7 @@ export default class PublishOptions extends Component {
             this.state.formStatus && this.state.formStatus == 'closed'
             ? <div>
               <Textfield
-                onChange={this.onInactiveMessageChange.bind(this)}
+                onChange={this.onInactiveMessageChange}
                 label="We are not currently accepting submissions..."
                 value={form.settings.inactiveMessage}
                 style={{ width: '95%', marginLeft: '5%' }}
@@ -103,7 +110,7 @@ export default class PublishOptions extends Component {
               ? <Button
                   style={{ width: 310, marginTop: 10, backgroundColor: '#353B43' }}
                   raised ripple accent
-                  onClick={this.togglePublishModal.bind(this)}>
+                  onClick={this.togglePublishModal}>
                   Publish options
                 </Button>
               : null
@@ -116,7 +123,7 @@ export default class PublishOptions extends Component {
               noFooter
               style={styles.publishModal}
               title="Publish Options"
-              cancelAction={this.togglePublishModal.bind(this)}
+              cancelAction={this.togglePublishModal}
               isOpen={this.state.publishModalOpened}>
 
               <div style={ styles.dialogContent }>


### PR DESCRIPTION
## What does this PR do?

this PR does a couple of things. it removes `isActive` from the form `settings` object everywhere in cay. This was confusing, and as far as I can tell, not used.

the second big things is that after the form's `status` is updated, the app automatically saves to the server. This should alleviate weirdness when you change the status of a form, but it's still unreachable.

Also, in the `PublishOptions` component, the form status was being saved in state and not persisted. I've updated this as well.

I removed the status dropdown from the form creation screen because it didn't really mean anything at that point.
## How do I test this PR?
- load up a form. (Form Edit, Submission List, Gallery Manager)
- change the status from the dropdown. it should save.

@coralproject/frontend
