### PR TITLE
Not saving form before the apply button is clicked

### DIFF
--- a/src/app/FormEdit.jsx
+++ b/src/app/FormEdit.jsx
@@ -70,11 +70,7 @@ export default class FormEdit extends Component {
   }
 
   updateFormStatus(value) {
-    const {dispatch, forms} = this.props;
-    // hack. this needs to be fixed.
-    dispatch(updateFormStatus(forms.activeForm, value)).then(updatedForm => {
-      dispatch(saveForm(updatedForm, forms.widgets));
-    });
+    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
   }
 
   updateInactive(value) {

--- a/src/app/GalleryManager.jsx
+++ b/src/app/GalleryManager.jsx
@@ -149,10 +149,7 @@ export default class GalleryManager extends Component {
   }
 
   updateFormStatus(value) {
-    const {dispatch, forms} = this.props;
-    dispatch(updateFormStatus(forms.activeForm, value)).then(updatedForm => {
-      dispatch(saveForm(updatedForm, forms.widgets));
-    });
+    this.props.dispatch(updateFormStatus(this.props.forms.activeForm, value));
   }
 
   getAttributionFields(form) {


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/coralproject/ask/issues/121
Wait for clicking on the `apply` button to save the form.
## How do I test this PR?
- Go to a form
- Change the status
- Widget status shouldn't change (if it was closed it should remain closed)
- Click on apply
- Widget status should change

@coralproject/frontend
