### PR TITLE
restore react-mdl imports

### DIFF
--- a/src/services/styles.js
+++ b/src/services/styles.js
@@ -10,3 +10,5 @@ import 'ask-gallery-preview.css';
 import 'react-select.css';
 import 'react-datepicker.min.css';
 import '../../fonts/glyphicons-halflings-regular.woff';
+
+import 'material.css';


### PR DESCRIPTION
## What does this PR do?

apparently removing the `react-mdl` from the bulid (as opposed to importing the css in `index.html`) breaks random stuff. This is a very exciting feature.
## How do I test this PR?
- go to View Forms
- click the Live/Closed buttons. the sidebar should no longer collapse.

@coralproject/frontend
