### PR TITLE
Allow cay to proxy requests to elkhorn, xenia and shelf

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -3,6 +3,7 @@ var express = require('express');
 var http = require('http');
 var webpack = require('webpack');
 var config = require('./webpack.config.dev');
+var proxy = require('express-http-proxy');
 var Dashboard = require('webpack-dashboard');
 var DashboardPlugin = require('webpack-dashboard/plugin');
 
@@ -23,6 +24,9 @@ app.use(require('webpack-dev-middleware')(compiler, {
 
 app.use(require('webpack-hot-middleware')(compiler, {log: () => {}}));
 
+app.use('/xenia', proxy('http://localhost:16181'));
+app.use('/ask', proxy('http://localhost:16181'));
+app.use('/elkhorn', proxy('http://localhost:4444'));
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });

--- a/dev-server.js
+++ b/dev-server.js
@@ -27,10 +27,10 @@ app.use(require('webpack-hot-middleware')(compiler, {log: () => {}}));
 
 // Setup proxy routes to use on Hosts that only expose one external port (i.e.
 // Heroku)
-var config = JSON.parse(fs.readFileSync('public/config.json'));
-app.use('/xenia', proxy(config.xeniaHost));
-app.use('/ask', proxy(config.askHost));
-app.use('/elkhorn', proxy(config.elkhornHost));
+var feConfig = JSON.parse(fs.readFileSync('public/config.json'));
+app.use('/xenia', proxy(feConfig.xeniaHost));
+app.use('/ask', proxy(feConfig.askHost));
+app.use('/elkhorn', proxy(feConfig.elkhornHost));
 
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));

--- a/dev-server.js
+++ b/dev-server.js
@@ -2,6 +2,7 @@ var path = require('path');
 var express = require('express');
 var http = require('http');
 var webpack = require('webpack');
+var fs = require('fs');
 var config = require('./webpack.config.dev');
 var proxy = require('express-http-proxy');
 var Dashboard = require('webpack-dashboard');
@@ -24,18 +25,23 @@ app.use(require('webpack-dev-middleware')(compiler, {
 
 app.use(require('webpack-hot-middleware')(compiler, {log: () => {}}));
 
-app.use('/xenia', proxy('http://localhost:16181'));
-app.use('/ask', proxy('http://localhost:16181'));
-app.use('/elkhorn', proxy('http://localhost:4444'));
+// Setup proxy routes to use on Hosts that only expose one external port (i.e.
+// Heroku)
+var config = JSON.parse(fs.readFileSync('public/config.json'));
+app.use('/xenia', proxy(config.xeniaHost));
+app.use('/ask', proxy(config.askHost));
+app.use('/elkhorn', proxy(config.elkhornHost));
+
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
-server.listen(3000, 'localhost', function(err) {
+var port = process.env.PORT || 3000;
+server.listen(port, 'localhost', function(err) {
   if (err) {
     console.log(err);
     return;
   }
 
-  console.log('Listening at http://localhost:3000');
+  console.log('Listening at http://localhost:'+port);
 });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "css-loader": "^0.21.0",
     "d3": "^3.5.12",
     "exports-loader": "^0.6.3",
+    "express-http-proxy": "^0.10.0",
     "file-loader": "^0.8.4",
     "font-awesome": "^4.4.0",
     "font-awesome-webpack": "0.0.4",

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -20,10 +20,9 @@ export const loadConfig = () =>
     }
 
     // handle proy config
-    app.proxy = app.proxy || false
-    app.askHost = app.proxy ? "/ask" : app.askHost
-    app.xeniaHost = app.proxy ? "/xenia" : app.xeniaHost
-    app.elkhornHost = app.proxy ? "/elkhorn" : app.elkhornHost
+    app.askHost = app.proxy ? '/ask' : app.askHost;
+    app.xeniaHost = app.proxy ? '/xenia' : app.xeniaHost;
+    app.elkhornHost = app.proxy ? '/elkhorn' : app.elkhornHost;
 
     // redefine elkhornStaticHost if not set
     app.elkhornStaticHost = app.elkhornStaticHost || `${app.elkhornHost}/widgets`;

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -18,6 +18,13 @@ export const loadConfig = () =>
     if (!allKeysDefined(app, REQUIRED_KEYS)) {
       throw new Error(`missing required keys on config.json. Must define ${REQUIRED_KEYS.join('|')}`);
     }
+
+    // handle proy config
+    app.proxy = app.proxy || false
+    app.askHost = app.proxy ? "/ask" : app.askHost
+    app.xeniaHost = app.proxy ? "/xenia" : app.xeniaHost
+    app.elkhornHost = app.proxy ? "/elkhorn" : app.elkhornHost
+
     // redefine elkhornStaticHost if not set
     app.elkhornStaticHost = app.elkhornStaticHost || `${app.elkhornHost}/widgets`;
 


### PR DESCRIPTION
## What does this PR do?

Added proxy routes to cay that will talk to elkhorn, xenia and shelf. This is needed in order for Ask to be functional on Heroku.
## How do I test this PR?
- Deploy to Heroku
- Create a form
- Save form
- Preview form

@coralproject/frontend
