### PR TITLE
add feature to execute a runtimeSetupScript during the first request

### DIFF
--- a/public/config.sample.json
+++ b/public/config.sample.json
@@ -15,5 +15,7 @@
     "trust": true,
     "ask": true
   },
-  "recaptcha": false
+  "recaptcha": false,
+  "proxy": false,
+  "setupRuntimeScript": ""
 }


### PR DESCRIPTION
## What does this PR do?

Add's a `runtimeSetupScript` configuration and logic to execute that script on the first request. Currently, the script is passed the host of the first request. This will be used to set the auth environment for Heroku.
## How do I test this PR?
- Create a script
- Configure it as the runtimeSetupScript
- Go to cay
- Check that the script gets executed only on the first run

@coralproject/frontend
