### PR TITLE
toggle Auth

### DIFF
--- a/public/config.sample.json
+++ b/public/config.sample.json
@@ -12,6 +12,7 @@
   "authClientId": "example_client_id",
   "authAuthority": "<authServerHost>/connect",
   "features": {
+    "authEnabled": false,
     "trust": true,
     "ask": true
   },

--- a/src/App.js
+++ b/src/App.js
@@ -38,35 +38,49 @@ const UserIsAuthenticated = UserAuthWrapper({
  * Expose App base component. Handle all routes
  */
 
+const buildRoutes = (store, onLogPageView, defaultRoute, features, userManager) => {
+
+  const getComponent = component => features.authEnabled ? UserIsAuthenticated(component) : component;
+
+  const router = (
+    <Router history={browserHistory} onUpdate={onLogPageView}>
+      <Redirect from="/" to={defaultRoute} />
+      <Route path="login" component={Login} />
+      <Route path="about" component={About} />
+      <Route path="/callback" component={CallbackPage} />
+      {features.trust !== false ?
+        <div>
+          <Route path="search-creator" component={SearchCreator} />
+          <Route path="saved-searches" component={SeeAllSearches}/>
+          <Route path="saved-search/:id" component={SearchDetail} />
+          <Route path="edit-search/:id" component={SearchEditor} />
+        </div>
+      : null}
+      {features.ask ?
+        <div>
+          <Route path="forms" component={getComponent(FormList)} />
+          <Route path="forms/create" component={getComponent(FormCreate)}/>
+          <Route path="forms/:id" component={getComponent(FormEdit)}/>
+          <Route path="forms/:id/submissions" component={getComponent(SubmissionList)}/>
+          <Route path="forms/:id/gallery" component={getComponent(GalleryManager)}/>
+        </div>
+      : null}
+      <Route path="*" component={NoMatch} />
+    </Router>
+  );
+
+  if (features.authEnabled) {
+    return <OidcProvider store={store} userManager={userManager}>{router}</OidcProvider>;
+  } else {
+    return router;
+  }
+
+};
+
 export default ({ store, onLogPageView, defaultRoute, features, userManager }) => (
   <StyleRoot>
     <Provider store={store}>
-      <OidcProvider store={store} userManager={userManager}>
-        <Router history={browserHistory} onUpdate={onLogPageView}>
-          <Redirect from="/" to={defaultRoute} />
-          <Route path="login" component={Login} />
-          <Route path="about" component={About} />
-          <Route path="/callback" component={CallbackPage} />
-          {features.trust !== false ?
-            <div>
-              <Route path="search-creator" component={SearchCreator} />
-              <Route path="saved-searches" component={SeeAllSearches}/>
-              <Route path="saved-search/:id" component={SearchDetail} />
-              <Route path="edit-search/:id" component={SearchEditor} />
-            </div>
-          : null}
-          {features.ask ?
-            <div>
-              <Route path="forms" component={UserIsAuthenticated(FormList)} />
-              <Route path="forms/create" component={UserIsAuthenticated(FormCreate)}/>
-              <Route path="forms/:id" component={UserIsAuthenticated(FormEdit)}/>
-              <Route path="forms/:id/submissions" component={UserIsAuthenticated(SubmissionList)}/>
-              <Route path="forms/:id/gallery" component={UserIsAuthenticated(GalleryManager)}/>
-            </div>
-          : null}
-          <Route path="*" component={NoMatch} />
-        </Router>
-      </OidcProvider>
+      {buildRoutes(store, onLogPageView, defaultRoute, features, userManager)}
     </Provider>
   </StyleRoot>
 );

--- a/src/App.js
+++ b/src/App.js
@@ -58,10 +58,10 @@ export default ({ store, onLogPageView, defaultRoute, features, userManager }) =
           {features.ask ?
             <div>
               <Route path="forms" component={UserIsAuthenticated(FormList)} />
-              <Route path="forms/create" component={FormCreate}/>
-              <Route path="forms/:id" component={FormEdit}/>
-              <Route path="forms/:id/submissions" component={SubmissionList}/>
-              <Route path="forms/:id/gallery" component={GalleryManager}/>
+              <Route path="forms/create" component={UserIsAuthenticated(FormCreate)}/>
+              <Route path="forms/:id" component={UserIsAuthenticated(FormEdit)}/>
+              <Route path="forms/:id/submissions" component={UserIsAuthenticated(SubmissionList)}/>
+              <Route path="forms/:id/gallery" component={UserIsAuthenticated(GalleryManager)}/>
             </div>
           : null}
           <Route path="*" component={NoMatch} />

--- a/src/app/AppActions.js
+++ b/src/app/AppActions.js
@@ -10,6 +10,7 @@ import XeniaDriver from 'xenia-driver';
  */
 
 export const CONFIG_ERROR = 'CONFIG_ERROR';
+export const AUTH_SNACKBAR_DISPLAYED_ONCE = 'AUTH_SNACKBAR_DISPLAYED_ONCE';
 
 
 /**
@@ -32,3 +33,5 @@ export const configXenia = () => (dispatch, getState) => {
  */
 
 export const configError = message => ({ type: CONFIG_ERROR, message });
+
+export const authSnackbarDisplayedOnce = () => ({type: AUTH_SNACKBAR_DISPLAYED_ONCE});

--- a/src/app/AppReducer.js
+++ b/src/app/AppReducer.js
@@ -9,10 +9,15 @@ import * as types from 'app/AppActions';
  * App reducer
  */
 
-export default (state = {}, action) => {
+const initialState = {authSnackbarDisplayedOnce: false};
+
+export default (state = initialState, action) => {
   switch (action.type) {
   case types.CONFIG_ERROR:
     return { ...state, configErrorMessage: action.message };
+
+  case types.AUTH_SNACKBAR_DISPLAYED_ONCE:
+    return {...state, authSnackbarDisplayedOnce: true};
 
   default:
     return state;

--- a/src/app/FormCreate.jsx
+++ b/src/app/FormCreate.jsx
@@ -12,7 +12,8 @@ import {
   createEmpty,
   updateFormSettings,
   leavingEdit
- } from 'forms/FormActions';
+} from 'forms/FormActions';
+import { authSnackbarDisplayedOnce } from 'app/AppActions';
 import { showFlashMessage } from 'flashmessages/FlashMessagesActions';
 import Login from 'app/Login';
 import Page from 'app/layout/Page';
@@ -20,6 +21,7 @@ import FormBuilder from 'forms/FormBuilder.js';
 import FormChrome from 'app/layout/FormChrome';
 
 @connect(({ oidc, app, forms }) => ({
+  app,
   elkhornHost: app.elkhornHost,
   oidc,
   forms
@@ -45,6 +47,10 @@ export default class FormCreate extends Component {
     }
   }
 
+  componentWillUnmount() {
+    this.props.dispatch(authSnackbarDisplayedOnce());
+  }
+
   updateInactive(value) {
     this.props.dispatch(updateFormSettings({ inactiveMessage: value }));
   }
@@ -55,11 +61,19 @@ export default class FormCreate extends Component {
   }
 
   render() {
-    if (!this.props.oidc.user) return <Login />;
-
+    const {oidc, app} = this.props;
     const { preview } = this.state;
+
+    if (!oidc.user) return <Login />;
+
+    const authTimeout = new Date(this.props.oidc.user.expires_at * 1000);
+
     return (
-      <Page style={styles.page}>
+      <Page
+        style={styles.page}
+        authTimeout={authTimeout}
+        displayAuthSnackbar={!app.authSnackbarDisplayedOnce}
+        >
         <FormChrome form={null}
           create={true}
           updateStatus={() => null}

--- a/src/app/FormCreate.jsx
+++ b/src/app/FormCreate.jsx
@@ -63,10 +63,7 @@ export default class FormCreate extends Component {
   render() {
     const {oidc, app} = this.props;
     const { preview } = this.state;
-
-    if (!oidc.user) return <Login />;
-
-    const authTimeout = new Date(this.props.oidc.user.expires_at * 1000);
+    const authTimeout = app.features.authEnabled ? new Date(oidc.user.expires_at * 1000) : undefined;
 
     return (
       <Page

--- a/src/app/FormEdit.jsx
+++ b/src/app/FormEdit.jsx
@@ -86,10 +86,7 @@ export default class FormEdit extends Component {
     const submissions = submissionList.map(id => forms[id]);
     const form = forms[activeForm];
     const gallery = forms[activeGallery];
-
-    if (!oidc.user) return <Login />;
-
-    const authTimeout = new Date(oidc.user.expires_at * 1000);
+    const authTimeout = app.features.authEnabled ? new Date(oidc.user.expires_at * 1000) : undefined;
 
     return (
       <Page authTimeout={authTimeout} displayAuthSnackbar={!app.authSnackbarDisplayedOnce}>

--- a/src/app/FormEdit.jsx
+++ b/src/app/FormEdit.jsx
@@ -15,7 +15,7 @@ import {
   leavingEdit,
   updateFormSettings,
   fetchForm } from 'forms/FormActions';
-
+import { authSnackbarDisplayedOnce } from 'app/AppActions';
 import Login from 'app/Login';
 import Page from 'app/layout/Page';
 import FormChrome from 'app/layout/FormChrome';
@@ -25,7 +25,7 @@ import FormBuilder from 'forms/FormBuilder.js';
  * Expose Form Edit page component
  */
 
-@connect(({ oidc, forms }) => ({ oidc, forms }))
+@connect(({ app, oidc, forms }) => ({ app, oidc, forms }))
 @Radium
 export default class FormEdit extends Component {
 
@@ -48,6 +48,10 @@ export default class FormEdit extends Component {
     const {dispatch, params} = this.props;
     dispatch(requestEditAccess(params.id));
     dispatch(fetchForm(params.id));
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(authSnackbarDisplayedOnce());
   }
 
   leavingEdit() {
@@ -77,7 +81,7 @@ export default class FormEdit extends Component {
   }
 
   render() {
-    const { oidc, forms, route } = this.props;
+    const { app, oidc, forms, route } = this.props;
     const { submissionList, activeForm, activeGallery } = forms;
     const submissions = submissionList.map(id => forms[id]);
     const form = forms[activeForm];
@@ -85,8 +89,10 @@ export default class FormEdit extends Component {
 
     if (!oidc.user) return <Login />;
 
+    const authTimeout = new Date(oidc.user.expires_at * 1000);
+
     return (
-      <Page>
+      <Page authTimeout={authTimeout} displayAuthSnackbar={!app.authSnackbarDisplayedOnce}>
         <FormChrome
           activeTab="builder"
           updateStatus={this.updateFormStatus}

--- a/src/app/FormList.jsx
+++ b/src/app/FormList.jsx
@@ -7,6 +7,7 @@ import React, { PropTypes, Component } from 'react';
 import Radium from 'radium';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import { authSnackbarDisplayedOnce } from 'app/AppActions';
 import { deleteForm, fetchForms } from 'forms/FormActions';
 import { mediumGrey, brandColor } from 'settings';
 import Page from 'app/layout/Page';
@@ -19,7 +20,7 @@ import Login from 'app/Login';
 import { CoralButton } from '../components/ui';
 
 // Forms, Widgets, Submissions
-@connect(({ oidc, forms }) => ({ oidc, forms }))
+@connect(({ app, oidc, forms }) => ({ app, oidc, forms }))
 @Radium
 export default class FormList extends Component {
   constructor(props) {
@@ -42,6 +43,10 @@ export default class FormList extends Component {
     if (!this.props.forms.formList) {
       this.props.dispatch(fetchForms());
     }
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(authSnackbarDisplayedOnce());
   }
 
   confirmDeletion(name, description, index, event) {
@@ -78,7 +83,7 @@ export default class FormList extends Component {
 
   render() {
 
-    const {oidc, forms} = this.props;
+    const {app, oidc, forms} = this.props;
 
     if (oidc.isLoadingUser) {
       return <p>Authorizing user...</p>;
@@ -91,9 +96,10 @@ export default class FormList extends Component {
     const allForms = forms.formList.map(id => forms[id]);
     const visibleForms = allForms.filter(form => form.status === this.state.displayMode);
     const { displayMode } = this.state;
+    const authTimeout = new Date(oidc.user.expires_at * 1000);
 
     return (
-      <Page>
+      <Page authTimeout={authTimeout} displayAuthSnackbar={!app.authSnackbarDisplayedOnce}>
         <ContentHeader title="View Forms" style={styles.header} subhead="Create, edit and view forms">
           <Link to="forms/create" style={styles.createButton}>
             <CoralButton icon="add" type="success">

--- a/src/app/FormList.jsx
+++ b/src/app/FormList.jsx
@@ -84,19 +84,10 @@ export default class FormList extends Component {
   render() {
 
     const {app, oidc, forms} = this.props;
-
-    if (oidc.isLoadingUser) {
-      return <p>Authorizing user...</p>;
-    }
-
-    if (!oidc.user) {
-      return <Login />;
-    }
-
     const allForms = forms.formList.map(id => forms[id]);
     const visibleForms = allForms.filter(form => form.status === this.state.displayMode);
     const { displayMode } = this.state;
-    const authTimeout = new Date(oidc.user.expires_at * 1000);
+    const authTimeout = app.features.authEnabled ? new Date(oidc.user.expires_at * 1000) : undefined;
 
     return (
       <Page authTimeout={authTimeout} displayAuthSnackbar={!app.authSnackbarDisplayedOnce}>

--- a/src/app/GalleryManager.jsx
+++ b/src/app/GalleryManager.jsx
@@ -307,10 +307,7 @@ export default class GalleryManager extends Component {
   render() {
 
     const {forms, oidc, app} = this.props;
-
-    if (!oidc.user) return <Login />;
-
-    const authTimeout = new Date(oidc.user.expires_at * 1000);
+    const authTimeout = app.features.authEnabled ? new Date(oidc.user.expires_at * 1000) : undefined;
 
     const form = forms[forms.activeForm];
     const gallery = forms[forms.activeGallery] || {

--- a/src/app/GalleryManager.jsx
+++ b/src/app/GalleryManager.jsx
@@ -22,6 +22,7 @@ import {
   beginEdit,
   reinsertGalleryAnswer
 } from 'forms/FormActions';
+import {authSnackbarDisplayedOnce} from 'app/AppActions';
 import {Link} from 'react-router';
 import moment from 'moment';
 
@@ -39,7 +40,6 @@ import GalleryPreview from 'forms/GalleryPreview';
 
 import TextField from 'components/forms/TextField';
 import Button from 'components/Button';
-import Modal from 'components/modal/Modal';
 
 import GalleryAnswer from 'forms/GalleryAnswer';
 import PublishOptions from 'forms/PublishOptions';
@@ -75,6 +75,10 @@ export default class GalleryManager extends Component {
     // for the nav to have the correct count of submissions for this form/gallery
     this.props.dispatch(fetchSubmissions(this.props.params.id));
     this.props.dispatch(fetchGallery(this.props.params.id));
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(authSnackbarDisplayedOnce());
   }
 
   removeSubmission(galleryId, submissionId, answerId) {
@@ -302,9 +306,11 @@ export default class GalleryManager extends Component {
 
   render() {
 
-    const {forms, oidc} = this.props;
+    const {forms, oidc, app} = this.props;
 
     if (!oidc.user) return <Login />;
+
+    const authTimeout = new Date(oidc.user.expires_at * 1000);
 
     const form = forms[forms.activeForm];
     const gallery = forms[forms.activeGallery] || {
@@ -327,7 +333,7 @@ export default class GalleryManager extends Component {
     ];
 
     return (
-      <Page>
+      <Page authTimeout={authTimeout} displayAuthSnackbar={!app.authSnackbarDisplayedOnce}>
         <FormChrome
           activeTab="gallery"
           updateStatus={this.updateFormStatus}

--- a/src/app/Login.jsx
+++ b/src/app/Login.jsx
@@ -82,6 +82,7 @@ const styles = {
     fontWeight: 'bold',
     fontSize: '4em',
     marginTop: -10,
+    lineHeight: '1em',
     textShadow: `1px 1px 2px ${color(brandColor).darken(0.3).hexString()}`
   },
   container: {

--- a/src/app/MainReducer.js
+++ b/src/app/MainReducer.js
@@ -18,14 +18,17 @@ import flashMessages from 'flashmessages/FlashMessagesReducer';
  * Export combined reducer
  */
 
-export default combineReducers({
-  oidc,
-  app,
-  searches,
-  comments,
-  tags,
-  filters,
-  users,
-  forms,
-  flashMessages
-});
+export default initialState => {
+  return combineReducers({
+    oidc: initialState.app.features.authEnabled ? oidc : (state = {}) => state,
+    app,
+    searches,
+    comments,
+    tags,
+    filters,
+    users,
+    forms,
+    flashMessages
+  });
+
+};

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -24,7 +24,7 @@ import {
   cleanSubmissionFilters,
   downloadCSV
 } from 'forms/FormActions';
-
+import {authSnackbarDisplayedOnce} from 'app/AppActions';
 import SubmissionDetail from 'forms/SubmissionDetail';
 import FormChrome from 'app/layout/FormChrome';
 import Login from 'app/Login';
@@ -34,7 +34,7 @@ import Page from 'app/layout/Page';
  * Export submission list component
  */
 
-@connect(({ oidc, forms }) => ({ oidc, forms }))
+@connect(({ app, oidc, forms }) => ({ app, oidc, forms }))
 @Radium
 export default class SubmissionList extends Component {
   constructor(props) {
@@ -56,6 +56,10 @@ export default class SubmissionList extends Component {
     this.onDownloadCSV = this.onDownloadCSV.bind(this);
     this.removeFromGallery = this.removeFromGallery.bind(this);
     this.sendToGallery = this.sendToGallery.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(authSnackbarDisplayedOnce());
   }
 
   sendToGallery(galleryId, subId, key) {
@@ -104,7 +108,7 @@ export default class SubmissionList extends Component {
 
   render() {
 
-    const {oidc} = this.props;
+    const {oidc, app} = this.props;
     const { submissionList, activeSubmission, activeForm, activeGallery,
       submissionFilterBy, submissionOrder, formCounts } = this.props.forms;
     const submissions = submissionList.map(id => this.props.forms[id]);
@@ -114,8 +118,14 @@ export default class SubmissionList extends Component {
 
     if (!oidc.user) return <Login />;
 
+    const authTimeout = new Date(oidc.user.expires_at * 1000);
+
     return (
-      <Page style={styles.page}>
+      <Page
+        style={styles.page}
+        authTimeout={authTimeout}
+        displayAuthSnackbar={!app.authSnackbarDisplayedOnce}
+        >
         <div style={styles.container}>
           <FormChrome
             activeTab="submissions"

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -115,10 +115,7 @@ export default class SubmissionList extends Component {
     const submission = this.props.forms[activeSubmission];
     const form = this.props.forms[activeForm];
     const gallery = this.props.forms[activeGallery];
-
-    if (!oidc.user) return <Login />;
-
-    const authTimeout = new Date(oidc.user.expires_at * 1000);
+    const authTimeout = app.features.authEnabled ? new Date(oidc.user.expires_at * 1000) : undefined;
 
     return (
       <Page

--- a/src/app/layout/Page.jsx
+++ b/src/app/layout/Page.jsx
@@ -18,7 +18,7 @@ import settings from 'settings';
 export default class Page extends React.Component {
 
   static propTypes = {
-    authTimeout: PropTypes.instanceOf(Date),
+    authTimeout: PropTypes.instanceOf(Date), // could be Date or null
     displayAuthSnackbar: PropTypes.bool
   }
 

--- a/src/app/layout/Page.jsx
+++ b/src/app/layout/Page.jsx
@@ -4,7 +4,7 @@ Page is not a smart component, but it holds all the other layout elements
 and all the other smart components (containers)
 
 */
-import React from 'react';
+import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import {Snackbar} from 'react-mdl';
 import Sidebar from 'app/layout/sidebar';
@@ -17,6 +17,11 @@ import settings from 'settings';
 @Radium
 export default class Page extends React.Component {
 
+  static propTypes = {
+    authTimeout: PropTypes.instanceOf(Date),
+    displayAuthSnackbar: PropTypes.bool
+  }
+
   constructor(props) {
     super(props);
     this.state = {isSnackbarActive: true};
@@ -28,6 +33,18 @@ export default class Page extends React.Component {
     this.setState({ isSnackbarActive: false });
   }
 
+  formatTimeUntilLogout(expiry) {
+    const now = new Date();
+    const oneHour = 36E5;
+    const oneMinute = 6E4;
+
+    if ((expiry - now) / oneMinute < 60) {
+      return `${Math.floor((expiry - now) / oneMinute)} minutes`;
+    } else if ((expiry - now) / oneHour < 40) {
+      return `${Math.floor((expiry - now) / oneHour)} hours`;
+    }
+  }
+
   render() {
     return (
       <Sidebar styles={styles.sidebar}>
@@ -36,12 +53,17 @@ export default class Page extends React.Component {
         <div style={[styles.wrapper, this.props.style]}>
           {this.props.children}
         </div>
-        <Snackbar
-          timeout={4500}
-          onTimeout={this.handleSnackbarTimeout}
-          active={this.state.isSnackbarActive}>
-          {'Welcome! You have 60 minutes before your session expires and you\'re automatically logged out'}
-        </Snackbar>
+        {
+          this.props.authTimeout && this.props.displayAuthSnackbar
+          ? <Snackbar
+            timeout={4500}
+            onTimeout={this.handleSnackbarTimeout}
+            active={this.state.isSnackbarActive}>
+            {`Welcome! You have ${this.formatTimeUntilLogout(this.props.authTimeout)} before your session expires and you're automatically logged out`}
+          </Snackbar>
+          : null
+        }
+
       </Sidebar>
     );
   }

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -103,15 +103,17 @@ export const COPY_FORM = 'COPY_FORM';
  * Utils
  */
 
-const getInit = (method, body, token = '') => {
-  const init = {
-    method: method || 'POST',
-    headers: new Headers({
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      'Authorization': token
-    })
-  };
+const getInit = (method, body, oidc = {}) => {
+  const headers = new Headers({
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+  });
+
+  if (oidc.user) {
+    headers.append('Authorization', oidc.user.id_token);
+  }
+
+  const init = { method, headers };
 
   if (method !== 'GET' && body) init.body = JSON.stringify(body);
 
@@ -191,13 +193,9 @@ const answerRemovedFromGallery = gallery => ({
 export const fetchForms = () => (dispatch, getState) => {
   const {oidc, app} = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   dispatch(formsRequestStarted());
 
-  return fetch(`${app.askHost}/v1/form`, getInit('GET', null, oidc.user.id_token))
+  return fetch(`${app.askHost}/v1/form`, getInit('GET', null, oidc))
     .then(handleResp)
     .then(forms => dispatch(formsRequestSuccess(forms)))
     .catch(error => dispatch(formsRequestFailure(error)));
@@ -206,13 +204,9 @@ export const fetchForms = () => (dispatch, getState) => {
 export const fetchForm = id => (dispatch, getState) => {
   const {app, oidc} = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   dispatch(formRequestStarted(id));
 
-  return fetch(`${app.askHost}/v1/form/${id}`, getInit('GET', null, oidc.user.id_token))
+  return fetch(`${app.askHost}/v1/form/${id}`, getInit('GET', null, oidc))
     .then(handleResp)
     .then(form => dispatch(formRequestSuccess(form)))
     .catch(error => dispatch(formRequestFailure(error)));
@@ -230,12 +224,8 @@ export const copyForm = (id) => (dispatch, getState) => {
 export const deleteForm = (name, description, id) => (dispatch, getState) => {
   const {app, oidc} = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   dispatch(formRequestStarted(id));
-  return fetch(`${app.askHost}/v1/form/${id}`, getInit('DELETE', { name, description }, oidc.user.id_token))
+  return fetch(`${app.askHost}/v1/form/${id}`, getInit('DELETE', { name, description }, oidc))
     .then(handleResp)
     .then(deletedForm => {
       dispatch(deleteSuccessful(id));
@@ -300,14 +290,10 @@ export const saveForm = (form, widgets) => {
 
     const {app, oidc} = getState();
 
-    if (!authenticated(oidc)) {
-      return;
-    }
-
     data.settings.saveDestination =  `${app.askHost}/v1/form/${form.id}/submission`;
 
     dispatch({ type: CREATE_INIT_FORM, data });
-    return fetch(`${app.elkhornHost}/create`, getInit('POST', data, oidc.user.id_token))
+    return fetch(`${app.elkhornHost}/create`, getInit('POST', data, oidc))
     .then(handleResp)
     .then(json => {
       dispatch(formCreated(json));
@@ -321,15 +307,11 @@ export const editForm = form => (dispatch, getState) => {
   const data = {...form};
   const {app, oidc} = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   // update save destination on edit to capture config changes
   data.settings.saveDestination = `${app.askHost}/v1/form/${form.id}/submission`;
 
   dispatch({type: EDIT_FORM_REQUEST, data});
-  return fetch(`${app.elkhornHost}/create`, getInit('POST', data, oidc.user.id_token))
+  return fetch(`${app.elkhornHost}/create`, getInit('POST', data, oidc))
   .then(handleResp)
   .then(json => {
     dispatch({type: EDIT_FORM_SUCCESS, data: json});
@@ -344,12 +326,8 @@ export const updateInactiveMessage = (message, form) => (dispatch, getState) => 
 
   const { app, oidc } = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   dispatch({ type: UPDATE_FORM_INACTIVE_MESSAGE_REQUEST });
-  return fetch(`${app.elkhornHost}/create`, getInit('POST', formData, oidc.user.id_token))
+  return fetch(`${app.elkhornHost}/create`, getInit('POST', formData, oidc))
   .then(handleResp)
   .then(json => {
     dispatch({type: UPDATE_FORM_INACTIVE_MESSAGE_SUCCESS, data: json});
@@ -366,13 +344,9 @@ export const fetchSubmissions = (formId, page = 0) => (dispatch, getState) => {
   const filterBy = submissionFilterBy === 'default' ? '' : submissionFilterBy;
   const skip = page * 10;
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   return fetch(
     `${app.askHost}/v1/form/${formId}/submission?skip=${skip}&limit=10&orderby=${submissionOrder}&filterby=${filterBy}&search=${submissionSearch}`,
-    getInit('GET', null, oidc.user.id_token)
+    getInit('GET', null, oidc)
   )
     .then(handleResp)
     .then(data => dispatch(submissionsFetched(data.counts, data.submissions || [])))
@@ -391,10 +365,6 @@ export const updateSubmissionFlags = props => (dispatch, getState) => {
   // Create an array with the old and new flags
   const allKeys = keys.concat(forms[activeSubmission].flags);
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   dispatch(updateActiveSubmission({
     // remove the flags that are for removing and prevent duplicates using a Set
     flags: [...new Set(allKeys.filter(k => props[k] !== false))]
@@ -406,7 +376,7 @@ export const updateSubmissionFlags = props => (dispatch, getState) => {
   return Promise.all(keys.map(prop =>
     fetch(
       `${app.askHost}/v1/form/${activeForm}/submission/${activeSubmission}/flag/${prop}`,
-      getInit( props[prop] ? 'POST': 'DELETE', null, oidc.user.id_token)
+      getInit( props[prop] ? 'POST': 'DELETE', null, oidc)
     )
     .then(handleResp)
   ));
@@ -417,11 +387,7 @@ export const fetchGallery = formId => (dispatch, getState) => {
 
   const {app, oidc} = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
-  fetch(`${app.askHost}/v1/form/${formId}/gallery`, getInit('GET', null, oidc.user.id_token))
+  fetch(`${app.askHost}/v1/form/${formId}/gallery`, getInit('GET', null, oidc))
     .then(handleResp)
     .then(galleries => dispatch(receivedGallery(galleries[0]))) // we only support 1 gallery
     .catch(error => dispatch(galleryRequestError(error)));
@@ -435,7 +401,7 @@ export const sendToGallery = (galleryId, subId, answerId) => {
       return;
     }
 
-    fetch(`${app.askHost}/v1/form_gallery/${galleryId}/submission/${subId}/${answerId}`, getInit('POST', null, oidc.user.id_token))
+    fetch(`${app.askHost}/v1/form_gallery/${galleryId}/submission/${subId}/${answerId}`, getInit('POST', null, oidc))
       .then(handleResp)
       .then(gallery => {
         dispatch({type: FORM_ANSWER_SENT_TO_GALLERY, gallery});
@@ -448,11 +414,7 @@ export const removeFromGallery = (galleryId, subId, answerId) => {
   return (dispatch, getState) => {
     const { app, oidc } = getState();
 
-    if (!authenticated(oidc)) {
-      return;
-    }
-
-    fetch(`${app.askHost}/v1/form_gallery/${galleryId}/submission/${subId}/${answerId}`, getInit('DELETE', null, oidc.user.id_token))
+    fetch(`${app.askHost}/v1/form_gallery/${galleryId}/submission/${subId}/${answerId}`, getInit('DELETE', null, oidc))
       .then(handleResp)
       .then(gallery => dispatch(answerRemovedFromGallery(gallery)))
       .catch(error => {
@@ -470,11 +432,7 @@ export const updateFormStatus = (formId, status) => (dispatch, getState) => disp
 export const publishFormStatus = (formId, status) => (dispatch, getState) => {
   const {app, oidc} = getState();
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
-  return fetch(`${app.askHost}/v1/form/${formId}/status/${status}`, getInit('PUT', null, oidc.user.id_token))
+  return fetch(`${app.askHost}/v1/form/${formId}/status/${status}`, getInit('PUT', null, oidc))
     .then(handleResp)
     .then(form => {
       dispatch(updateFormStatus(formId, status));
@@ -544,13 +502,9 @@ export const editAnswer = (edited, submission_id, answer_id, formId) => {
 
     const {app, oidc} = getState();
 
-    if (!authenticated(oidc)) {
-      return;
-    }
-
     fetch(
       `${app.askHost}/v1/form/${formId}/submission/${submission_id}/answer/${answer_id}`,
-      getInit('PUT', {edited}, oidc.user.id_token)
+      getInit('PUT', {edited}, oidc)
     )
       .then(handleResp)
       .then(submission => {
@@ -604,13 +558,9 @@ export const publishGallery = () => (dispatch, getState) => {
   const { activeGallery } = forms;
   const gallery = forms[activeGallery];
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
   dispatch({type: PUBLISH_GALLERY_REQUEST});
 
-  return fetch(`${app.elkhornHost}/gallery/${gallery.id}/publish`, getInit('POST', gallery, oidc.user.id_token))
+  return fetch(`${app.elkhornHost}/gallery/${gallery.id}/publish`, getInit('POST', gallery, oidc))
   .then(handleResp)
   .then(gallery => {
     dispatch({type: PUBLISH_GALLERY_SUCCESS, gallery});
@@ -652,11 +602,7 @@ export const downloadCSV = formId => (dispatch, getState) => {
   const { submissionFilterBy, submissionSearch } = forms;
   const filterBy = submissionFilterBy === 'default' ? '' : submissionFilterBy;
 
-  if (!authenticated(oidc)) {
-    return;
-  }
-
-  fetch(`${app.askHost}/v1/form/${formId}/submission/export?filterby=${filterBy}&search=${submissionSearch}`, getInit('GET', null, oidc.user.id_token))
+  fetch(`${app.askHost}/v1/form/${formId}/submission/export?filterby=${filterBy}&search=${submissionSearch}`, getInit('GET', null, oidc))
   .then(handleResp)
   .then(({ csv_url }) => window.open(`${csv_url}&filterby=${filterBy}&search=${submissionSearch}`, '_self')); // download by opening a new tab
 };

--- a/src/forms/FormActions.js
+++ b/src/forms/FormActions.js
@@ -123,7 +123,7 @@ const getInit = (method, body, oidc = {}) => {
 const handleResp = res => {
   if (res.status === 401) {
     throw new Error('Not Authorized to make this request');
-  } else if (status > 399) {
+  } else if (res.status > 399) {
     throw new Error('Error! Status ' + res.status);
   } else {
     return res.json();

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import configureStore from 'store.js';
-import {userManager} from 'store';
+import configureStore, {userManager} from 'store';
 import { configXenia } from 'app/AppActions';
 
 import App from 'App';


### PR DESCRIPTION
## What does this PR do?
- updates the Auth Snackbar to:
  - only show once upon successful authentication
  - show hours/minutes until logout
- adds authorization to the other Ask pages
- exposes a flag to make authorization enabled/disabled
## How do I test this PR?
- log in
- you should see something like "you have 35 hours until you're logged out"
- click to another screen in Ask
- you should not see the snackbar
- add the flag `authEnabled` to the `features` object in `config.json`
- setting it to `true` and `false` should toggle auth
- obviously, if auth is "on" on the backend, you'll get a 401 even if auth is "off" on the frontend

@coralproject/frontend 
