### PR TITLE
[BOCOUP] Add includeInGroups and groupSubmission inputs

### DIFF
--- a/css/material.css
+++ b/css/material.css
@@ -45,3 +45,19 @@
   font-size: 16px;
   padding-top: 3px;
 }
+.mdl-tooltip{
+  opacity: 0;
+}
+
+.mdl-tooltip.is-active {
+  animation: none;
+  transform: scale(1);
+  opacity: 1;
+  visibility: visible;
+
+  -webkit-transform: translate3d(0,-10px,0);
+  transform: translate3d(0,-10px,0);
+  -webkit-transition: opacity 0.3s, -webkit-transform 0.3s;
+  transition: opacity 0.3s, transform 0.3s;
+  -webkit-transform: translateZ(0);
+}

--- a/src/components/ui/Tooltip.js
+++ b/src/components/ui/Tooltip.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react';
+
+export const Tooltip = ({ text, for }) => (
+  <span
+    className={`mdl-tooltip`}
+    for={for}
+  >
+    {text}
+  </span>
+);
+
+Tooltip.propTypes = {
+  text: PropTypes.string.isRequired,
+  for: PropTypes.isRequired,
+};

--- a/src/components/ui/Tooltip.js
+++ b/src/components/ui/Tooltip.js
@@ -27,7 +27,7 @@ export default class Tooltip extends Component {
 
   render() {
     const { text, htmlFor, children } = this.props;
-    const { active, x, y } = this.state;
+    const { active } = this.state;
     return (
       <span
         onMouseOver={this.handleMouseOver}

--- a/src/components/ui/Tooltip.js
+++ b/src/components/ui/Tooltip.js
@@ -1,15 +1,57 @@
-import React, { PropTypes } from 'react';
+import React, { Component,  PropTypes } from 'react';
 
-export const Tooltip = ({ text, for }) => (
-  <span
-    className={`mdl-tooltip`}
-    for={for}
-  >
-    {text}
-  </span>
-);
+export default class Tooltip extends Component {
+  static propTypes = {
+    text: PropTypes.string.isRequired,
+    htmlFor: PropTypes.string.isRequired,
+  };
 
-Tooltip.propTypes = {
-  text: PropTypes.string.isRequired,
-  for: PropTypes.isRequired,
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      active: false
+    };
+
+    this.handleMouseOver = this.handleMouseOver.bind(this);
+    this.handleMouseOut = this.handleMouseOut.bind(this);
+  }
+
+  handleMouseOver(e) {
+    this.setState({ active: true });
+  }
+
+  handleMouseOut(e) {
+    this.setState({ active: false });
+  }
+
+  render() {
+    const { text, htmlFor, children } = this.props;
+    const { active, x, y } = this.state;
+    return (
+      <span
+        onMouseOver={this.handleMouseOver}
+        onMouseOut={this.handleMouseOut}
+        style={{ position: 'relative'}}
+      >
+        {children}
+        <span
+          className={`mdl-tooltip ${(active) ? 'is-active' : ''}`}
+          style={styles}
+          htmlFor={htmlFor}
+        >
+          {text}
+        </span>
+      </span>
+    );
+  }
+}
+
+const styles = {
+  position: 'absolute',
+  left: 0,
+  top: 'auto',
+  bottom: -50,
 };
+
+

--- a/src/components/ui/Tooltip.js
+++ b/src/components/ui/Tooltip.js
@@ -53,5 +53,3 @@ const styles = {
   top: 'auto',
   bottom: -50,
 };
-
-

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -4,3 +4,4 @@ export { default as CoralButton } from './CoralButton';
 export { default as CoralDialog } from './CoralDialog';
 export { default as CoralTabBar } from './CoralTabBar';
 export { default as CoralTab } from './CoralTab';
+export { default as Tooltip } from './Tooltip';

--- a/src/forms/editors/MultipleChoiceEditor.jsx
+++ b/src/forms/editors/MultipleChoiceEditor.jsx
@@ -7,7 +7,7 @@ import CommonFieldOptions from 'forms/CommonFieldOptions';
 import FaCopy from 'react-icons/lib/fa/copy';
 import FaPlusCircle from 'react-icons/lib/fa/plus-circle';
 
-import { CoralIconButton } from '../../components/ui';
+import { CoralIconButton, Tooltip } from '../../components/ui';
 
 @connect(({ forms, app }) => ({ forms, app }))
 @Radium
@@ -22,6 +22,11 @@ export default class MultipleChoiceEditor extends Component {
     };
 
     this.addOption = this.addOption.bind(this);
+    this.onMultipleClick = this.onMultipleClick.bind(this);
+    this.onOtherTextChange = this.onOtherTextChange.bind(this);
+    this.onOtherClick = this.onOtherClick.bind(this);
+    this.onGroupClick = this.onGroupClick.bind(this);
+    this.onIncludeInGroupClick = this.onIncludeInGroupClick.bind(this);
 
     this.focusNew = false;
   }
@@ -174,7 +179,7 @@ export default class MultipleChoiceEditor extends Component {
             field.props.otherAllowed ?
               <div style={ styles.optionRow }>
                 <div style={ styles.optionRowText }>
-                  <input style={ styles.optionInput } type="text" placeholder="Other:" value={ field.props.otherText } onChange={ this.onOtherTextChange.bind(this) } />
+                  <input style={ styles.optionInput } type="text" placeholder="Other:" value={ field.props.otherText } onChange={this.onOtherTextChange} />
                 </div>
                 <div style={ styles.optionRowButtons }>
                   &nbsp;
@@ -191,32 +196,39 @@ export default class MultipleChoiceEditor extends Component {
             </div>
           </div>
         </div>
-        <div style={ styles.bottomOptions }>
-          <div style={ styles.bottomOptionsLeft }>
-            <label style={ styles.bottomCheck }>
+        <div style={styles.bottomOptions}>
+          <div style={styles.bottomOptionsLeft}>
+            <label style={styles.bottomCheck}>
               <input type="checkbox"
-                onClick={ this.onMultipleClick.bind(this) }
-                checked={ field.props.multipleChoice } />
+                onClick={this.onMultipleClick}
+                checked={field.props.multipleChoice} />
                 Allow multiple selections
             </label>
-            <label style={ styles.bottomCheck }>
+            <label style={styles.bottomCheck}>
               <input type="checkbox"
-                onClick={ this.onOtherClick.bind(this) }
-                checked={ field.props.otherAllowed } />
+                onClick={this.onOtherClick}
+                checked={field.props.otherAllowed} />
                 Allow "Other"
             </label>
-            <label style={ styles.bottomCheck }>
+            <Tooltip htmlFor="groupSubmissions"  text="Create counts by answer for multiple choice questions">
+              <label style={styles.bottomCheck}>
+                <input
+                  id="groupSubmissions"
+                  type="checkbox"
+                  onClick={this.onGroupClick}
+                  checked={field.props.groupSubmissions } />
+                  Group submissions (API)
+              </label>
+            </Tooltip>
+            <Tooltip htmlFor="includeInGroups"  text="Include these answers in grouped submissions">
+            <label style={styles.bottomCheck}>
               <input type="checkbox"
-                onClick={ this.onGroupClick.bind(this) }
-                checked={ field.props.groupSubmissions } />
-                Group Submissions
-            </label>
-            <label style={ styles.bottomCheck }>
-              <input type="checkbox"
-                onClick={ this.onIncludeInGroupClick.bind(this) }
-                checked={ field.props.includeInGroups } />
+                id="includeInGroups"
+                onClick={this.onIncludeInGroupClick}
+                checked={field.props.includeInGroups} />
                 Include in Groups
             </label>
+          </Tooltip>
           </div>
           <CommonFieldOptions {...this.props} />
         </div>

--- a/src/forms/editors/MultipleChoiceEditor.jsx
+++ b/src/forms/editors/MultipleChoiceEditor.jsx
@@ -226,7 +226,7 @@ export default class MultipleChoiceEditor extends Component {
                 id="includeInGroups"
                 onClick={this.onIncludeInGroupClick}
                 checked={field.props.includeInGroups} />
-                Include in Groups
+                Include in Groups (API)
             </label>
           </Tooltip>
           </div>

--- a/src/forms/editors/TextAreaEditor.jsx
+++ b/src/forms/editors/TextAreaEditor.jsx
@@ -6,6 +6,7 @@ import CommonFieldOptions from 'forms/CommonFieldOptions'
 
 import editWidgetStyles from 'forms/editors/EditWidgetStyles'
 import CheckInput from '../../components/forms/CheckInput'
+import { Tooltip } from '../../components/ui';
 
 @connect(({ forms, app }) => ({ forms, app }))
 @Radium
@@ -121,14 +122,16 @@ export default class TextAreaEditor extends Component {
               handleInput={handleMaxInput}
               defaultValue={field.props.maxLength}
             />
-            <label>
-              <input type="checkbox"
-                className="form-include-in-groups"
-                onChange={ (e) => this.onIncludeInGroups(e) }
-                value={ field.props.includeInGroups } 
-                checked={ field.props.includeInGroups } />
-                Include in Groups
-            </label>
+            <Tooltip htmlFor="includeInGroups"  text="Include these answers in grouped submissions">
+              <label style={styles.bottomCheck}>
+                <input type="checkbox"
+                  className="form-include-in-groups"
+                  onChange={ (e) => this.onIncludeInGroups(e) }
+                  value={ field.props.includeInGroups }
+                  checked={ field.props.includeInGroups } />
+                  Include in Groups (API)
+              </label>
+            </Tooltip>
           </div>
           <CommonFieldOptions
             {...this.props}
@@ -151,8 +154,11 @@ const styles = {
   },
   bottomCheck: {
     display: 'inline-block',
-    padding: '10px 20px 10px 0',
+    fontSize: '10pt',
+    marginBottom: '20px',
     cursor: 'pointer',
+    lineHeight: '30px',
+    marginRight: '5px'
   },
   bottomOptions: {
     display: 'flex',

--- a/src/forms/editors/TextFieldEditor.jsx
+++ b/src/forms/editors/TextFieldEditor.jsx
@@ -7,6 +7,8 @@ import editWidgetStyles from 'forms/editors/EditWidgetStyles'
 
 import CheckInput from '../../components/forms/CheckInput'
 
+import { Tooltip } from '../../components/ui';
+
 @connect(({ forms, app }) => ({ forms, app }))
 @Radium
 export default class TextFieldEditor extends Component {
@@ -121,14 +123,18 @@ export default class TextFieldEditor extends Component {
               handleInput={handleMaxInput}
               defaultValue={field.props.maxLength}
             />
-            <label>
-              <input type="checkbox"
-                className="form-include-in-groups"
-                onChange={ (e) => this.onIncludeInGroups(e) }
-                value={ field.props.includeInGroups } 
-                checked={ field.props.includeInGroups } />
-                Include in Groups
-            </label>
+            <Tooltip htmlFor="includeInGroups"  text="Include these answers in grouped submissions">
+              <label style={styles.bottomCheck}>
+                <input
+                  type="checkbox"
+                  id="includeInGroups"
+                  className="form-include-in-groups"
+                  onChange={ (e) => this.onIncludeInGroups(e) }
+                  value={ field.props.includeInGroups }
+                  checked={ field.props.includeInGroups } />
+                  Include in Groups (API)
+              </label>
+            </Tooltip>
           </div>
           <CommonFieldOptions
             {...this.props}
@@ -150,9 +156,11 @@ const styles = {
   },
   bottomCheck: {
     display: 'inline-block',
-    padding: '10px 0 10px 10px',
+    fontSize: '10pt',
+    marginBottom: '20px',
     cursor: 'pointer',
-    lineHeight: '30px'
+    lineHeight: '30px',
+    marginRight: '5px'
   },
   bottomOptions: {
     display: 'flex',


### PR DESCRIPTION
## What does this PR do?

This pr introduces two props to the into the form creator:
- groupSubmissions on multiple choice questions indicates that submissions will be grouped by the answer to this question when doing aggregations. In doing so, it allows us to understand how people _who answered this question in each way_ answered the other questions in the form.
- includeInGroups indicates that text based responses be included in group aggregations. This allows us to control which text fields will be grouped (organized into lists).
## How do I test this PR?
- Go to the Create / Edit form interface
- Add a text area.
- Ensure that the Group Submissions checkbox sets props correctly.
- Add a Short Answer and Long Answer field. 
- Ensure that the Include in Groups checkbox sets into props.

With the coral-bocoup branches of elklhorn and askd publishing functionality can also be tested
- on a form that has at least one Group By checked
- create some submissions
- bookmark them
- see that digest and submission group files are written to the same place that elkhorn would be publishing the forms/galleries.

@coralproject/frontend
