### PR TITLE
Edit form fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,7 @@ const buildRoutes = (store, onLogPageView, defaultRoute, features, userManager) 
 
   const UserIsAuthenticated = UserAuthWrapper({
     authSelector: state => state.oidc.user,
-    authenticatingSelector: state => {console.log('authenticatingSelector', state.oidc); return state.oidc.isLoadingUser;},
+    authenticatingSelector: state => state.oidc.isLoadingUser,
     LoadingComponent: LoadingAuth,
     wrapperDisplayName: 'UserIsAuthenticated'
     // /login is the default, but putting it here for notes to future self

--- a/src/App.js
+++ b/src/App.js
@@ -26,19 +26,20 @@ import GalleryManager from 'app/GalleryManager';
 
 import CallbackPage from 'app/CallbackPage';
 
-const UserIsAuthenticated = UserAuthWrapper({
-  authSelector: state => state.oidc.user,
-  authenticatingSelector: state => state.oidc.isLoadingUser,
-  wrapperDisplayName: 'UserIsAuthenticated',
-  // /login is the default, but putting it here for notes to future self
-  failureRedirectPath: '/login'
-});
 
 /**
  * Expose App base component. Handle all routes
  */
 
 const buildRoutes = (store, onLogPageView, defaultRoute, features, userManager) => {
+
+  const UserIsAuthenticated = UserAuthWrapper({
+    authSelector: state => state.oidc.user,
+    authenticatingSelector: state => state.oidc.isLoadingUser,
+    wrapperDisplayName: 'UserIsAuthenticated',
+    // /login is the default, but putting it here for notes to future self
+    redirectAction: userManager.signinRedirect
+  });
 
   const getComponent = component => features.authEnabled ? UserIsAuthenticated(component) : component;
 

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ import NoMatch from 'app/NoMatch';
 import About from 'app/About';
 import SubmissionList from 'app/SubmissionList';
 import GalleryManager from 'app/GalleryManager';
-
+import LoadingAuth from 'app/LoadingAuth';
 import CallbackPage from 'app/CallbackPage';
 
 
@@ -35,12 +35,11 @@ const buildRoutes = (store, onLogPageView, defaultRoute, features, userManager) 
 
   const UserIsAuthenticated = UserAuthWrapper({
     authSelector: state => state.oidc.user,
-    authenticatingSelector: state => state.oidc.isLoadingUser,
-    wrapperDisplayName: 'UserIsAuthenticated',
+    authenticatingSelector: state => {console.log('authenticatingSelector', state.oidc); return state.oidc.isLoadingUser;},
+    LoadingComponent: LoadingAuth,
+    wrapperDisplayName: 'UserIsAuthenticated'
     // /login is the default, but putting it here for notes to future self
-    redirectAction: userManager.signinRedirect
   });
-
   const getComponent = component => features.authEnabled ? UserIsAuthenticated(component) : component;
 
   const router = (

--- a/src/app/LoadingAuth.jsx
+++ b/src/app/LoadingAuth.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
 
-export default class LoadingAuth extends React.Component {
-  render() {
-    return (
-      <p>Authorizing...</p>
-    );
-  }
-}
+export default () => (
+  <p>Authorizing...</p>
+);

--- a/src/app/LoadingAuth.jsx
+++ b/src/app/LoadingAuth.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default class LoadingAuth extends React.Component {
+  render() {
+    return (
+      <p>Authorizing...</p>
+    );
+  }
+}

--- a/src/app/SubmissionList.jsx
+++ b/src/app/SubmissionList.jsx
@@ -27,7 +27,6 @@ import {
 import {authSnackbarDisplayedOnce} from 'app/AppActions';
 import SubmissionDetail from 'forms/SubmissionDetail';
 import FormChrome from 'app/layout/FormChrome';
-import Login from 'app/Login';
 import Page from 'app/layout/Page';
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import configureStore, {userManager} from 'store';
+import getStore, {userManager} from 'store';
 import { configXenia } from 'app/AppActions';
+import { userFound } from 'redux-oidc';
 
 import App from 'App';
 import 'i18n';
@@ -24,20 +25,27 @@ import { FILTERS_CONFIG_LOADED } from 'filters/FiltersActions';
 
 loadConfig()
 .then(([app, filters]) => {
-  const store = configureStore({ app });
+  getStore({app}).then(([store, user]) => {
 
-  store.dispatch(configXenia());
-  if (app.features.trust === true) {
-    store.dispatch({type: FILTERS_CONFIG_LOADED, config: filters});
-  }
+    if (user) {
+      // I don't know if this is strictly necessary
+      // I want to force the user into the state if it's there.
+      store.dispatch(userFound(user));
+    }
 
-  analyticsInit(app.googleAnalyticsId);
+    store.dispatch(configXenia());
+    if (app.features.trust === true) {
+      store.dispatch({type: FILTERS_CONFIG_LOADED, config: filters});
+    }
 
-  const { features } = app;
-  ReactDOM.render(
-    <App store={store} onLogPageView={logPageView} features={features} userManager={userManager}
-      defaultRoute={getDefaultRoute(features)} />
-  , document.getElementById('root'));
+    analyticsInit(app.googleAnalyticsId);
+
+    const { features } = app;
+    ReactDOM.render(
+      <App store={store} onLogPageView={logPageView} features={features} userManager={userManager}
+        defaultRoute={getDefaultRoute(features)} />
+    , document.getElementById('root'));
+  });
 });
 
 /**

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,7 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import createOidcMiddleware, {createUserManager} from 'redux-oidc';
+import {WebStorageStateStore} from 'oidc-client';
 import createDebounce from 'redux-debounce';
 import getRootReducer from 'app/MainReducer';
 
@@ -18,6 +19,7 @@ export let userManagerConfig = {
   authority: null, // also populated after config is loaded
   post_logout_redirect_uri: `${window.location.protocol}//${window.location.host}/login`,
   loadUserInfo: false,
+  userStore: new WebStorageStateStore({store: window.localStorage}),
   monitorSession: false
 };
 
@@ -38,23 +40,34 @@ export default initialState => {
   // https://github.com/maxmantz/redux-oidc/wiki/3.-API
   const debouncer = createDebounce({ userMangerFilters: 500 });
   const middleware = [thunk, debouncer];
-
-  if (initialState.app.features.authEnabled) {
-    userManager = createUserManager(userManagerConfig);
-    const oidcMiddleware = createOidcMiddleware(userManager, () => true, true, '/callback');
-    middleware.push(oidcMiddleware);
-  }
-
   const devTools = typeof devToolsExtension !== 'undefined' ? devToolsExtension() : f => f;
 
-  /**
-   * Store creator based on environment
-   */
+  return new Promise(resolve => {
+    if (initialState.app.features.authEnabled) {
+      userManager = createUserManager(userManagerConfig);
+      const oidcMiddleware = createOidcMiddleware(userManager, null, false, '/callback', null);
+      middleware.push(oidcMiddleware);
+    }
 
-  const envCreateStore = process.env.NODE_ENV === 'production'
-    ? applyMiddleware(...middleware)(createStore)
-    : compose(applyMiddleware(...middleware), devTools)(createStore);
+    /**
+     * Store creator based on environment
+     */
 
+    const envCreateStore = process.env.NODE_ENV === 'production'
+      ? applyMiddleware(...middleware)(createStore)
+      : compose(applyMiddleware(...middleware), devTools)(createStore);
 
-  return envCreateStore(getRootReducer(initialState), initialState);
+    resolve(envCreateStore(getRootReducer(initialState), initialState));
+  }).then(store => {
+    if (initialState.app.features.authEnabled) {
+      // wait to initialize until the user + token is found in localStorage
+      return userManager.getUser().then(user => {
+        return Promise.all([store, user]);
+      });
+    } else {
+      return Promise.all([store, null]);
+    }
+  }).catch(error => {
+    console.error(error);
+  });
 };


### PR DESCRIPTION
## What does this PR do?

makes the store config function a Promise. This Promise will wait for the user to load if stored in `localStorage`. The result is that the moderator can click the browser Refresh button, and not be redirected to the login page if their token is not yet expired.
### NOTE

if you can think of a better way to do this, please feel free to poke around. From what I understand, the whole point of `redux-auth-wrapper` is that I don't have to do this, and it should just work. Am I reading the [configuration docs](https://github.com/mjrussell/redux-auth-wrapper) wrong?
## How do I test this PR?
- log in
- reload the page
- you should still be "logged in"

@coralproject/frontend
