### PR TITLE
Kill the Login screen dead

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,7 @@ const buildRoutes = (store, onLogPageView, defaultRoute, features, userManager) 
     authSelector: state => state.oidc.user,
     authenticatingSelector: state => state.oidc.isLoadingUser,
     LoadingComponent: LoadingAuth,
+    redirectAction: () => { userManager.signinRedirect(); },
     wrapperDisplayName: 'UserIsAuthenticated'
     // /login is the default, but putting it here for notes to future self
   });

--- a/src/app/Login.jsx
+++ b/src/app/Login.jsx
@@ -25,8 +25,8 @@ export default class Login extends React.Component {
     router: PropTypes.object.isRequired
   }
 
-  loginUser() {
-    // this.props.dispatch(login(this.state.email, this.state.password));
+  constructor(props) {
+    super(props);
     userManager.signinRedirect();
   }
 
@@ -37,16 +37,7 @@ export default class Login extends React.Component {
           <img style={styles.logo} src="/img/logomark_512x512.svg" />
           <p style={styles.welcome}>Welcome to</p>
           <p style={styles.projectName}>The Coral Project</p>
-          <div style={styles.container}>
-            <Button
-              className="login__button"
-              size="large"
-              style={styles.loginButton}
-              category="primary"
-              onClick={this.loginUser}
-            > Log In </Button>
-            <a style={styles.loginRequest} href="https://blog.coralproject.net/beta-testers/">How can I request a login?</a>
-          </div>
+          <p style={{color: 'white'}}>Redirecting...</p>
         </div>
       </div>
     );

--- a/src/app/Login.jsx
+++ b/src/app/Login.jsx
@@ -58,12 +58,6 @@ const styles = {
     margin: 'auto',
     width: 700
   },
-  cta: {
-    color: 'white',
-    fontWeight: 'bold',
-    fontSize: 20,
-    marginBottom: 10
-  },
   welcome: {
     color: 'white',
     fontSize: '2em',
@@ -77,46 +71,10 @@ const styles = {
     lineHeight: '1em',
     textShadow: `1px 1px 2px ${color(brandColor).darken(0.3).hexString()}`
   },
-  container: {
-    clear: 'both',
-    width: 500,
-    margin: 'auto',
-    paddingTop: 30,
-    paddingRight: 40,
-    paddingBottom: 10,
-    paddingLeft: 40
-  },
-  textInput: {
-    display: 'block',
-    width: '100%',
-    marginBottom: 15,
-    backgroundColor: 'white'
-  },
-  loginButton: {
-    marginTop: 12,
-    marginBottom: 25,
-    width: '100%',
-    borderColor: 'transparent',
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    ':hover': {
-      backgroundColor: 'rgba(255, 255, 255, 0.3)',
-      borderColor: 'transparent'
-    }
-  },
-  loginRequest: {
-    color: 'white'
-  },
   logo: {
     float: 'left',
     width: 128,
     height: 128,
     marginRight: 20
-  },
-  unauthorizedMessage: {
-    padding: '20px',
-    backgroundColor: 'rgba(255, 255, 255, 0.4)',
-    textAlign: 'center',
-    fontSize: '12pt',
-    color: 'white'
   }
 };


### PR DESCRIPTION
## What does this PR do?

The login screen is pointless. You shouldn't see it unless something has gone wrong, which it often does.
## How do I test this PR?
- go to `/login` in cay
- there should be no login button, just a message "redirecting..."
- you should be redirected to `coral-auth` to enter your creds.

@coralproject/frontend
